### PR TITLE
Supermemory run

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Paper: [arXiv](https://arxiv.org/abs/2605.11325) — Dataset: [HuggingFace](http
 | ----------------------- | ------------- | ------------ | -------------- | ----------- | ------------------ | ------------------- |
 | `tenure`                | 43/43         | 77/77        | 1.00           | 1.00        | 9.77               | 1.00                |
 | `open-knowledge-format` | 18/18         | 36/77        | 0.47           | 0.91        | 3534.53            | 0.00                |
-| `supermemory`           | 17/17         | 44/77        | 0.43           | 0.55        | 819.48             | 0.00                |
+| `supermemory`           | 4/4           | 21/77        | 0.22           | 0.71        | 69.41              | 5.20                |
 | `agentmemory`           | 0/0           | 7/77         | 0.17           | 0.97        | 82.28              | 1.10                |
 | `yourmemory`            | 0/0           | 21/77        | 0.17           | 0.88        | 313.39             | 16.40               |
 | `atomicmemory`          | 0/0           | 9/77         | 0.15           | 0.95        | 71.01              | 658.90              |
@@ -46,8 +46,8 @@ Total pass counts require this breakdown to be interpreted correctly. All counts
 | ----------------------- | ---------------- | ---------- | --------------- |
 | `tenure`                | 43               | 25         | 9               |
 | `open-knowledge-format` | 18               | 13         | 5               |
-| `supermemory`           | 17               | 18         | 9               |
 | `gbrain`                | 5                | 20         | 9               |
+| `supermemory`           | 4                | 14         | 3               |
 | `a-mem`                 | 0                | 6          | 3               |
 | `agentmemory`           | 0                | 5          | 2               |
 | `atomicmemory`          | 0                | 6          | 3               |
@@ -80,9 +80,9 @@ The drift score is the fraction of retrieved non-pinned beliefs originating from
 | Provider                | Turns passed | Pass rate | Mean drift | Noise isolation | Mean precision | Session p50 (ms) |
 | ----------------------- | ------------ | --------- | ---------- | --------------- | -------------- | ---------------- |
 | `tenure`                | 12/12        | 1.00      | 0.0000     | 1.00            | 1.0000         | 47.79            |
-| `supermemory`           | 2/12         | 0.17      | 0.1667     | 0.17            | 0.6000         | 867.83           |
 | `open-knowledge-format` | 2/12         | 0.17      | 0.2153     | 0.17            | 0.5694         | 3349.45          |
 | `yourmemory`            | 1/12         | 0.08      | 0.7365     | 0.08            | 0.1965         | 430.49           |
+| `supermemory`           | 1/12         | 0.08      | 0.7493     | 0.08            | 0.1825         | 172.32           |
 | `gbrain`                | 1/12         | 0.08      | 0.0000     | 0.08            | ---            | 535.61           |
 | `agentmemory`           | 0/12         | 0.00      | 0.8087     | 0.00            | 0.1913         | 98.49            |
 | `atomicmemory`          | 0/12         | 0.00      | 0.8449     | 0.00            | 0.1551         | 355.08           |

--- a/SUBMITTING.md
+++ b/SUBMITTING.md
@@ -4,8 +4,6 @@ To appear on the leaderboard, open a PR adding a wrapper for your provider to
 `wrappers/`. We run the eval against your wrapper -- you do not submit scores,
 we produce them.
 
----
-
 ## What a wrapper is
 
 A wrapper is a thin FastAPI service that normalizes your provider's API to the
@@ -23,8 +21,6 @@ The three files are:
 The `wrappers/` directory contains all existing integrations. Browse them for
 patterns before writing your own -- most common problems have already been
 solved there.
-
----
 
 ## API contract
 
@@ -88,8 +84,6 @@ Clear all stored beliefs for all users. Called once before seeding begins.
 { "ok": true }
 ```
 
----
-
 ## Mapping beliefId when your provider doesn't support metadata round-trip
 
 The eval harness maps your search results back to the belief corpus using the
@@ -107,8 +101,6 @@ wrapper uses this pattern and is a good reference for it.
 
 Your `/reset` endpoint must also clear this dict along with the provider's
 stored memories, or stale mappings will corrupt subsequent eval runs.
-
----
 
 ## Requirements
 
@@ -131,7 +123,32 @@ image: qdrant/qdrant@sha256:45f8e3ddc2570a4d029877e1b5ec1045c19b3852b4e22a55c7f4
 
 Mutable tags (`:latest`, `:main`, etc.) are not accepted.
 
-### 3. Environment variables
+### 3. Compiled local artifacts
+
+Most leaderboard submissions must be built from public source. A compiled-only provider submission is not accepted when the compiled artifact is the only thing a submitter provides.
+
+There is one narrow exception: PrecisionMemBench may evaluate an official local/self-hosted binary released by a provider when that binary is the normal artifact available to users and the run can be pinned and reproduced.
+
+For compiled local artifacts, the wrapper must document:
+
+- The upstream release URL
+- The provider version
+- The binary filename
+- The binary SHA256 digest
+- The Docker image name and SHA256 digest used for the eval
+- The benchmark commit used for the published run
+- Whether the wrapper injects any retrieval thresholds, ranking parameters, or provider-specific tuning
+- Any required external services, including LLM endpoints, embedding endpoints, telemetry endpoints, or hosted APIs observed during setup or execution
+
+The Dockerfile should download the exact release artifact and verify its SHA256 digest during build. The final `docker-compose.yml` should pin the published benchmark image by digest.
+
+A compiled artifact exception does not allow benchmark-specific behavior. The wrapper may adapt `/add`, `/search`, and `/reset`, but it must not modify provider ranking behavior, inject hidden thresholds, special-case benchmark belief IDs, or change seed data.
+
+For compiled local artifacts, the provider binary may be opaque, but the PrecisionMemBench wrapper may not be. The wrapper service source file, usually `<provider>_service.py`, must be committed to the repository alongside the Dockerfile and docker-compose.yml.
+
+The published Docker image may contain the wrapper source, but that is not sufficient for submission review. Reviewers must be able to inspect the wrapper directly in the PR to verify that it only adapts `/add`, `/search`, and `/reset`, and does not inject hidden thresholds, alter ranking behavior, special-case benchmark IDs, precompute answers, or modify the benchmark corpus.
+
+### 4. Environment variables
 
 Declare all required environment variables in your `docker-compose.yml`. The
 eval harness will not supply any credentials or configuration beyond what is
@@ -140,19 +157,17 @@ documented in your PR.
 The following variables from the mem0 reference are illustrative -- your
 provider will have its own:
 
-| Variable             | Purpose                                          |
-| -------------------- | ------------------------------------------------ |
-| `LLM_MODEL`          | The LLM your provider uses for memory extraction |
-| `LLM_BASE_URL`       | Base URL for LLM inference                       |
-| `LLM_API_KEY`        | API key for LLM inference                        |
-| `OLLAMA_EMBED_MODEL` | Embedding model name (if using Ollama)           |
-| `OLLAMA_URL`         | Ollama base URL (if using Ollama)                |
+| Variable | Purpose |
+| -- | |
+| `LLM_MODEL` | The LLM your provider uses for memory extraction |
+| `LLM_BASE_URL` | Base URL for LLM inference |
+| `LLM_API_KEY` | API key for LLM inference |
+| `OLLAMA_EMBED_MODEL` | Embedding model name (if using Ollama) |
+| `OLLAMA_URL` | Ollama base URL (if using Ollama) |
 
 The embedding model you use will be included in your leaderboard display name,
 e.g. `mem0 (mxbai-embed-large)`. If you use a proprietary embedder, document
 it clearly in your PR.
-
----
 
 ## Opening a submission PR
 
@@ -183,12 +198,19 @@ Create a PR against this repository with the following:
 <!-- If your provider uses an LLM for memory extraction, name it here -->
 <!-- This will be noted alongside your results -->
 
+## Artifact reproducibility
+
+<!-- Required for compiled local artifacts only -->
+<!-- Include upstream release URL, binary SHA256, Docker image digest, and benchmark commit -->
+
+## Network behavior
+
+<!-- Document required or observed outbound traffic: LLM endpoints, embedding services, telemetry, hosted APIs, or "none observed" -->
+
 ## Notes
 
 <!-- Anything relevant to reproducing your results -->
 ```
-
----
 
 ## What happens after you open a PR
 
@@ -208,7 +230,9 @@ will comment on the PR with the failure and you can revise.
 
 - Self-reported scores
 - Wrappers with mutable image tags (`:latest`, `:main`, etc.)
-- Closed-source provider implementations
+- Closed-source provider implementations submitted as unverifiable wrappers
+- Compiled-only submissions unless they are official local/self-hosted release artifacts pinned by upstream binary digest and Docker image digest
+- Docker images that contain wrapper behavior not represented by source files committed under `wrappers/<provider>/`
 - Wrappers that modify the eval harness or seed data
 - Wrappers that detect the eval environment and behave differently
 

--- a/SUBMITTING.md
+++ b/SUBMITTING.md
@@ -235,11 +235,13 @@ will comment on the PR with the failure and you can revise.
 - Docker images that contain wrapper behavior not represented by source files committed under `wrappers/<provider>/`
 - Wrappers that modify the eval harness or seed data
 - Wrappers that detect the eval environment and behave differently
+- Hosted cloud APIs are not accepted for the main leaderboard track unless PrecisionMemBench defines a separate hosted-provider track. The main track requires a reproducible local/self-hosted artifact pinned by source commit, binary digest, Docker image digest, or equivalent immutable release artifact.
 
-The public repo requirement exists so that any auditor can verify your
-implementation is not special-casing the benchmark. If your code reads the
-belief IDs at startup and pre-caches responses, that will be visible and the
-submission will be removed.
+The reproducibility and auditability requirements exist so reviewers can verify the benchmark boundary. Provider behavior must be pinned through an accepted artifact: public source, an official local/self-hosted binary with a verified digest, or a Docker image pinned by digest. The PrecisionMemBench wrapper itself must always be committed as readable source under `wrappers/<provider>/`.
+
+Reviewers must be able to confirm that the wrapper only adapts `/add`, `/search`, and `/reset`. It must not special-case benchmark IDs, pre-cache answers, inject hidden thresholds, alter ranking behavior, modify seed data, or behave differently when it detects the eval environment.
+
+Compiled provider binaries are allowed only as pinned local release artifacts. The wrapper remains fully auditable source, and the submission must document artifact digests, network behavior, and required external services.
 
 ## Questions
 

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
   "scripts": {
     "eval": "npx ava retrieval.external.eval.test.ts && npx ava session-retrieval.external.eval.test.ts",
     "eval:fresh": "RESEED=true npm run eval",
-    "eval:vector": "npx ava retrieval.vector.eval.test.ts && npx ava session-retrieval.vector.eval.test.ts",
-    "embed-seed": "npx tsx src/utils/embed-seed.ts",
-    "export": "python export_to_hf.py"
+    "eval:vector": "npx ava retrieval.vector.eval.test.ts && npx ava session-retrieval.vector.eval.test.ts"
   },
   "devDependencies": {
     "@types/node": "25.9.1",

--- a/test-results/baseline/retrieval-report-supermemory.json
+++ b/test-results/baseline/retrieval-report-supermemory.json
@@ -1,75 +1,75 @@
 {
   "provider": "supermemory",
   "retrieval": {
-    "meanLatencyMs": 821.27,
-    "p50LatencyMs": 819.48,
-    "p95LatencyMs": 1228.91,
+    "meanLatencyMs": 72.09,
+    "p50LatencyMs": 69.41,
+    "p95LatencyMs": 116.45,
     "caseCount": 77,
-    "meanPrecision": 0.4267,
-    "meanRecall": 0.5465,
-    "totalPassed": 44,
+    "meanPrecision": 0.2183,
+    "meanRecall": 0.7065,
+    "totalPassed": 21,
     "totalCases": 77,
-    "passRate": 0.5714,
-    "activeRetrievalPasses": 17,
+    "passRate": 0.2727,
+    "activeRetrievalPasses": 4,
     "passTypes": {
-      "activeRetrieval": 17,
-      "structural": 18,
-      "triviallyEmpty": 9
+      "activeRetrieval": 4,
+      "structural": 14,
+      "triviallyEmpty": 3
     },
     "categories": [
       {
         "category": "Alias resolution",
         "caseCount": 23,
-        "passed": 9,
-        "failed": 14,
-        "meanPrecision": 1,
-        "meanRecall": 0.3636
+        "passed": 3,
+        "failed": 20,
+        "meanPrecision": 0.3851,
+        "meanRecall": 0.7219
       },
       {
         "category": "Scope disambiguation",
         "caseCount": 12,
-        "passed": 9,
-        "failed": 3,
-        "meanPrecision": 0.6667,
+        "passed": 6,
+        "failed": 6,
+        "meanPrecision": 0.2109,
         "meanRecall": 0.875
       },
       {
         "category": "Fuzzy matching and prefix guards",
         "caseCount": 7,
-        "passed": 6,
-        "failed": 1,
-        "meanPrecision": 1,
-        "meanRecall": 0.8
+        "passed": 0,
+        "failed": 7,
+        "meanPrecision": 0.1881,
+        "meanRecall": 1
       },
       {
         "category": "Type routing and open questions",
         "caseCount": 6,
-        "passed": 2,
-        "failed": 4,
-        "meanPrecision": 0,
-        "meanRecall": 0
+        "passed": 1,
+        "failed": 5,
+        "meanPrecision": 0.0667,
+        "meanRecall": 1
       },
       {
         "category": "Design boundary cases",
         "caseCount": 6,
-        "passed": 6,
-        "failed": 0,
-        "meanPrecision": 1,
+        "passed": 2,
+        "failed": 4,
+        "meanPrecision": 0.0313,
         "meanRecall": 1
       },
       {
         "category": "Budget eviction and capacity",
         "caseCount": 5,
-        "passed": 4,
-        "failed": 1,
-        "meanPrecision": 1,
-        "meanRecall": 0.5
+        "passed": 3,
+        "failed": 2,
+        "meanPrecision": 0,
+        "meanRecall": 0
       },
       {
         "category": "Persona prelude content",
         "caseCount": 4,
-        "passed": 3,
-        "failed": 1,
+        "passed": 2,
+        "failed": 2,
         "meanPrecision": 0,
         "meanRecall": null
       },
@@ -78,39 +78,39 @@
         "caseCount": 4,
         "passed": 0,
         "failed": 4,
-        "meanPrecision": 0.6667,
-        "meanRecall": 1
+        "meanPrecision": 0.1667,
+        "meanRecall": 0.375
       },
       {
         "category": "Supersession chain exclusion",
         "caseCount": 3,
-        "passed": 0,
-        "failed": 3,
+        "passed": 1,
+        "failed": 2,
         "meanPrecision": 0,
         "meanRecall": null
       },
       {
         "category": "Ranking stability",
         "caseCount": 3,
-        "passed": 3,
-        "failed": 0,
-        "meanPrecision": 1,
-        "meanRecall": 1
+        "passed": 1,
+        "failed": 2,
+        "meanPrecision": 0.1714,
+        "meanRecall": 0.75
       },
       {
         "category": "Counter-signal retrieval",
         "caseCount": 2,
         "passed": 0,
         "failed": 2,
-        "meanPrecision": null,
-        "meanRecall": 0
+        "meanPrecision": 0.1,
+        "meanRecall": 0.5
       },
       {
         "category": "Cross-user isolation",
         "caseCount": 1,
         "passed": 1,
         "failed": 0,
-        "meanPrecision": null,
+        "meanPrecision": 0,
         "meanRecall": null
       },
       {
@@ -128,105 +128,95 @@
       "caseId": "happy-stack-repository-layer",
       "category": "Type routing and open questions",
       "description": "Repository layer query: pinned DB decision surfaces; scoped open question surfaces; relevant beliefs depend on query token overlap",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [
+        "b-composition-inheritance",
+        "b-mongo-raw-driver",
+        "b-kubernetes-entity",
+        "b-fastify-pref"
       ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": null,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
       "retrievalRecall": null,
       "pinnedCoverage": 1,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 1507.46
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-composition-inheritance",
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-kubernetes-entity",
+        "unexpected belief in relevantBeliefs: b-fastify-pref"
+      ],
+      "retrievalLatencyMs": 68.13
     },
     {
       "caseId": "happy-alias-match-kubernetes",
       "category": "Alias resolution",
       "description": "Alias 'k8s' resolves to Kubernetes entity",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [
-        "b-kubernetes-entity"
-      ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 1.0,
-      "retrievalRecall": 1.0,
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-kubernetes-entity"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 1,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
       "passed": true,
       "failures": [],
-      "retrievalLatencyMs": 803.83
+      "retrievalLatencyMs": 65.54
     },
     {
       "caseId": "alias-kube-resolves",
       "category": "Alias resolution",
       "description": "Alias 'kube' drives text search retrieval",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-kubernetes-entity"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 1,
+      "retrievalRecall": 0.5,
       "pinnedCoverage": null,
       "passed": false,
-      "failures": [
-        "missing expected belief: b-ci-gha-entity",
-        "missing expected belief: b-kubernetes-entity"
-      ],
-      "retrievalLatencyMs": 623.65
+      "failures": ["missing expected belief: b-ci-gha-entity"],
+      "retrievalLatencyMs": 73.45
     },
     {
       "caseId": "alias-gha-resolves",
       "category": "Alias resolution",
       "description": "Alias 'GHA' (short form) drives text-search retrieval of b-ci-gha-entity",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-auth-open-q"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
+      "retrievalRecall": 0,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
+        "unexpected belief in relevantBeliefs: b-auth-open-q",
         "missing expected belief: b-ci-gha-entity"
       ],
-      "retrievalLatencyMs": 708.43
+      "retrievalLatencyMs": 64.77
     },
     {
       "caseId": "long-query-rambling-kubernetes",
       "category": "Alias resolution",
       "description": "Verbose 400+ char query.",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [
+        "b-kubernetes-entity",
+        "b-auth-open-q",
+        "b-react-entity",
+        "b-redis-code",
+        "b-mongo-raw-driver"
       ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.2,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
-        "missing expected belief: b-kubernetes-entity"
+        "unexpected belief in relevantBeliefs: b-auth-open-q",
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-redis-code",
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver"
       ],
-      "retrievalLatencyMs": 724.77
+      "retrievalLatencyMs": 177.43
     },
     {
       "caseId": "out-of-scope-coin-collecting",
@@ -240,7 +230,7 @@
       "pinnedCoverage": null,
       "passed": true,
       "failures": [],
-      "retrievalLatencyMs": 615.18
+      "retrievalLatencyMs": 78.29
     },
     {
       "caseId": "happy-writing-scope",
@@ -252,15 +242,13 @@
         "b-prose-style-user-edited"
       ],
       "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-chapter-structure-q"
-      ],
+      "retrievedQuestions": ["b-chapter-structure-q"],
       "retrievalPrecision": null,
       "retrievalRecall": null,
       "pinnedCoverage": 1,
       "passed": true,
       "failures": [],
-      "retrievalLatencyMs": 617.37
+      "retrievalLatencyMs": 79.82
     },
     {
       "caseId": "conflict-scope-disambiguation-redis-writing",
@@ -271,44 +259,41 @@
         "b-protagonist-entity",
         "b-prose-style-user-edited"
       ],
-      "relevantBeliefs": [
-        "b-redis-writing"
-      ],
-      "retrievedQuestions": [
-        "b-chapter-structure-q"
-      ],
-      "retrievalPrecision": 1.0,
-      "retrievalRecall": 1.0,
+      "relevantBeliefs": ["b-redis-writing"],
+      "retrievedQuestions": ["b-chapter-structure-q"],
+      "retrievalPrecision": 1,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
       "passed": true,
       "failures": [],
-      "retrievalLatencyMs": 819.48
+      "retrievalLatencyMs": 69.71
     },
     {
       "caseId": "conflict-scope-disambiguation-redis-code",
       "category": "Scope disambiguation",
       "description": "'Redis' in code scope returns datastore, not character",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
         "b-redis-code",
-        "b-auth-depends-redis",
-        "b-auth-open-q"
+        "b-mongo-raw-driver",
+        "b-fastify-pref",
+        "b-react-entity",
+        "b-kubernetes-entity",
+        "b-sqlalchemy-superseded"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.3333333333333333,
-      "retrievalRecall": 1.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.16666666666666666,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
-        "unexpected belief in relevantBeliefs: b-auth-depends-redis",
-        "unexpected belief in relevantBeliefs: b-auth-open-q"
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-fastify-pref",
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-kubernetes-entity",
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded"
       ],
-      "retrievalLatencyMs": 814.06
+      "retrievalLatencyMs": 221.05
     },
     {
       "caseId": "multi-scope-redis-both-surfaces",
@@ -322,184 +307,180 @@
         "b-linting-current"
       ],
       "relevantBeliefs": [
-        "b-redis-code"
+        "b-redis-code",
+        "b-mongo-raw-driver",
+        "b-fastify-pref",
+        "b-kubernetes-entity",
+        "b-react-entity",
+        "b-sqlalchemy-superseded",
+        "b-auth-open-q"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q",
-        "b-chapter-structure-q"
-      ],
-      "retrievalPrecision": 1.0,
+      "retrievedQuestions": ["b-auth-open-q", "b-chapter-structure-q"],
+      "retrievalPrecision": 0.14285714285714285,
       "retrievalRecall": 0.5,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-fastify-pref",
+        "unexpected belief in relevantBeliefs: b-kubernetes-entity",
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded",
+        "unexpected belief in relevantBeliefs: b-auth-open-q",
         "missing expected belief: b-redis-writing"
       ],
-      "retrievalLatencyMs": 1025.47
+      "retrievalLatencyMs": 116.45
     },
     {
       "caseId": "conflict-mongodb-supersedes-sqlalchemy",
       "category": "Supersession chain exclusion",
       "description": "Superseded SQLAlchemy belief never surfaces",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
-        "b-sqlalchemy-superseded"
+        "b-sqlalchemy-superseded",
+        "b-mongo-raw-driver",
+        "b-kubernetes-entity"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
       "retrievalRecall": null,
       "pinnedCoverage": 1,
       "passed": false,
       "failures": [
-        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded"
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded",
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-kubernetes-entity"
       ],
-      "retrievalLatencyMs": 816.16
+      "retrievalLatencyMs": 67.15
     },
     {
       "caseId": "edge-empty-query",
       "category": "Design boundary cases",
       "description": "Empty query: persona + scope prelude + pinned facts injected, no relevant beliefs",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
+      "retrievedQuestions": ["b-auth-open-q"],
       "retrievalPrecision": null,
       "retrievalRecall": null,
       "pinnedCoverage": 1,
       "passed": true,
       "failures": [],
-      "retrievalLatencyMs": 0.08
+      "retrievalLatencyMs": 0.07
     },
     {
       "caseId": "edge-short-query-raw-passthrough",
       "category": "Alias resolution",
       "description": "Short query 'fastify?' passes raw to text search. Belief is pinned so verified in pinnedFacts.",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
-        "b-fastify-pref"
+        "b-fastify-pref",
+        "b-react-entity",
+        "b-mongo-raw-driver"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 1.0,
-      "retrievalRecall": 1.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.3333333333333333,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 819.81
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver"
+      ],
+      "retrievalLatencyMs": 56.83
     },
     {
       "caseId": "isolation-user-scoping",
       "category": "Cross-user isolation",
       "description": "Other-user beliefs never leak",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": null,
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-ts-pref"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
       "retrievalRecall": null,
       "pinnedCoverage": null,
       "passed": true,
       "failures": [],
-      "retrievalLatencyMs": 819.74
+      "retrievalLatencyMs": 65.82
     },
     {
       "caseId": "questions-pinned-active-only",
       "category": "Type routing and open questions",
       "description": "listPinnedOpenQuestions returns only pinned+active questions for the given scope",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
+      "retrievedQuestions": ["b-auth-open-q"],
       "retrievalPrecision": null,
       "retrievalRecall": null,
       "pinnedCoverage": null,
       "passed": true,
       "failures": [],
-      "retrievalLatencyMs": 637.47
+      "retrievalLatencyMs": 62.31
     },
     {
       "caseId": "alias-ts-resolves",
       "category": "Alias resolution",
       "description": "Alias 'TS' drives text-search retrieval.",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
-        "b-ts-pref"
+        "b-ts-pref",
+        "b-mongo-raw-driver",
+        "b-error-handling",
+        "b-react-entity",
+        "b-composition-inheritance"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 1.0,
-      "retrievalRecall": 1.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.2,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 1235.04
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-error-handling",
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-composition-inheritance"
+      ],
+      "retrievalLatencyMs": 69.31
     },
     {
       "caseId": "alias-mongo-resolves",
       "category": "Alias resolution",
       "description": "Alias 'Mongo' drives text-search retrieval.",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [
+        "b-mongo-raw-driver",
+        "b-error-handling",
+        "b-composition-inheritance",
+        "b-sqlalchemy-superseded",
+        "b-react-entity"
       ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.2,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
-        "missing expected belief: b-mongo-raw-driver"
+        "unexpected belief in relevantBeliefs: b-error-handling",
+        "unexpected belief in relevantBeliefs: b-composition-inheritance",
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded",
+        "unexpected belief in relevantBeliefs: b-react-entity"
       ],
-      "retrievalLatencyMs": 788.63
+      "retrievalLatencyMs": 72.43
     },
     {
       "caseId": "alias-reactjs-resolves",
       "category": "Alias resolution",
       "description": "Alias 'ReactJS' resolves to b-react-entity via text search \u2014 genuine retrieval proof",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-react-entity", "b-composition-inheritance"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.5,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
-        "missing expected belief: b-react-entity"
+        "unexpected belief in relevantBeliefs: b-composition-inheritance"
       ],
-      "retrievalLatencyMs": 761.68
+      "retrievalLatencyMs": 70.34
     },
     {
       "caseId": "alias-protagonist-resolves",
@@ -510,18 +491,18 @@
         "b-protagonist-entity",
         "b-prose-style-user-edited"
       ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-chapter-structure-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
+      "relevantBeliefs": ["b-redis-writing", "b-narrator-superseded"],
+      "retrievedQuestions": ["b-chapter-structure-q"],
+      "retrievalPrecision": 0,
+      "retrievalRecall": 0,
       "pinnedCoverage": 1,
       "passed": false,
       "failures": [
+        "unexpected belief in relevantBeliefs: b-redis-writing",
+        "unexpected belief in relevantBeliefs: b-narrator-superseded",
         "missing expected belief: b-pov-shift-entity"
       ],
-      "retrievalLatencyMs": 877.47
+      "retrievalLatencyMs": 76.55
     },
     {
       "caseId": "canonical-name-match-mara",
@@ -532,16 +513,14 @@
         "b-protagonist-entity",
         "b-prose-style-user-edited"
       ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-chapter-structure-q"
-      ],
-      "retrievalPrecision": null,
+      "relevantBeliefs": ["b-redis-writing"],
+      "retrievedQuestions": ["b-chapter-structure-q"],
+      "retrievalPrecision": 0,
       "retrievalRecall": null,
       "pinnedCoverage": 1,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 734.02
+      "passed": false,
+      "failures": ["unexpected belief in relevantBeliefs: b-redis-writing"],
+      "retrievalLatencyMs": 75.45
     },
     {
       "caseId": "alias-pov-shift-resolves",
@@ -552,550 +531,564 @@
         "b-protagonist-entity",
         "b-prose-style-user-edited"
       ],
-      "relevantBeliefs": [
-        "b-pov-shift-entity"
-      ],
-      "retrievedQuestions": [
-        "b-chapter-structure-q"
-      ],
-      "retrievalPrecision": 1.0,
-      "retrievalRecall": 1.0,
+      "relevantBeliefs": ["b-redis-writing", "b-narrator-superseded"],
+      "retrievedQuestions": ["b-chapter-structure-q"],
+      "retrievalPrecision": 0,
+      "retrievalRecall": 0,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 1107.67
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-redis-writing",
+        "unexpected belief in relevantBeliefs: b-narrator-superseded",
+        "missing expected belief: b-pov-shift-entity"
+      ],
+      "retrievalLatencyMs": 62.46
     },
     {
       "caseId": "alias-base-class-retrieves-composition",
       "category": "Alias resolution",
       "description": "Natural-language proxy 'base class' retrieves b-composition-inheritance (non-pinned) via alias",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [
+        "b-composition-inheritance",
+        "b-mongo-raw-driver",
+        "b-error-handling",
+        "b-sqlalchemy-superseded",
+        "b-fastify-pref"
       ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.2,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
-        "missing expected belief: b-composition-inheritance"
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-error-handling",
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded",
+        "unexpected belief in relevantBeliefs: b-fastify-pref"
       ],
-      "retrievalLatencyMs": 818.81
+      "retrievalLatencyMs": 77.77
     },
     {
       "caseId": "alias-exceptions-retrieves-error-handling",
       "category": "Alias resolution",
       "description": "Natural-language proxy 'exceptions' retrieves b-error-handling (non-pinned) via alias",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
-        "b-error-handling"
+        "b-error-handling",
+        "b-composition-inheritance",
+        "b-mongo-raw-driver"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 1.0,
-      "retrievalRecall": 1.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.3333333333333333,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 819.4
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-composition-inheritance",
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver"
+      ],
+      "retrievalLatencyMs": 67.62
     },
     {
       "caseId": "filter-resolved-at-excluded",
       "category": "Type routing and open questions",
       "description": "b-hosting-resolved has resolved_at set \u2014 query matching its aliases must not surface it",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
-        "b-hosting-resolved"
+        "b-fastify-pref",
+        "b-kubernetes-entity",
+        "b-react-entity"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
       "retrievalRecall": null,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
-        "unexpected belief in relevantBeliefs: b-hosting-resolved"
+        "unexpected belief in relevantBeliefs: b-fastify-pref",
+        "unexpected belief in relevantBeliefs: b-kubernetes-entity",
+        "unexpected belief in relevantBeliefs: b-react-entity"
       ],
-      "retrievalLatencyMs": 830
+      "retrievalLatencyMs": 80.44
     },
     {
       "caseId": "scope-bleed-questions-code-excludes-writing",
       "category": "Scope disambiguation",
       "description": "Code-scope query must not surface writing-scope open questions",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": null,
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-auth-open-q"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
       "retrievalRecall": null,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 808.22
+      "passed": false,
+      "failures": ["unexpected belief in relevantBeliefs: b-auth-open-q"],
+      "retrievalLatencyMs": 58.22
     },
     {
       "caseId": "persona-prelude-content-present",
       "category": "Persona prelude content",
       "description": "Persona prelude contains substantive content tokens derived from universal preferences",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
-        "b-react-entity"
+        "b-react-entity",
+        "b-sqlalchemy-superseded",
+        "b-kubernetes-entity"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
       "retrievalRecall": null,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
-        "unexpected belief in relevantBeliefs: b-react-entity"
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded",
+        "unexpected belief in relevantBeliefs: b-kubernetes-entity"
       ],
-      "retrievalLatencyMs": 818.08
+      "retrievalLatencyMs": 66.93
     },
     {
       "caseId": "edge-short-query-score-clears",
       "category": "Alias resolution",
       "description": "Short query 'k8s'",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-kubernetes-entity"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 1,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
-      "passed": false,
-      "failures": [
-        "missing expected belief: b-kubernetes-entity"
-      ],
-      "retrievalLatencyMs": 818.95
+      "passed": true,
+      "failures": [],
+      "retrievalLatencyMs": 61.13
     },
     {
       "caseId": "edge-whitespace-query",
       "category": "Design boundary cases",
       "description": "Whitespace-only query is treated as empty by queryExpander \u2014 no relevant beliefs",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
+      "retrievedQuestions": ["b-auth-open-q"],
       "retrievalPrecision": null,
       "retrievalRecall": null,
       "pinnedCoverage": null,
       "passed": true,
       "failures": [],
-      "retrievalLatencyMs": 0.05
+      "retrievalLatencyMs": 0.06
     },
     {
       "caseId": "score-boundary-weak-match-filtered",
       "category": "Design boundary cases",
       "description": "Weakly-related in-scope query does not surface tangential beliefs below minScore",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [
+        "b-kubernetes-entity",
+        "b-fastify-pref",
+        "b-composition-inheritance",
+        "b-mongo-raw-driver"
       ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": null,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
       "retrievalRecall": null,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 919.44
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-kubernetes-entity",
+        "unexpected belief in relevantBeliefs: b-fastify-pref",
+        "unexpected belief in relevantBeliefs: b-composition-inheritance",
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver"
+      ],
+      "retrievalLatencyMs": 66.61
     },
     {
       "caseId": "user-edited-cross-scope-surfaces",
       "category": "Scope disambiguation",
       "description": "user_edited belief scoped to domain:writing does NOT surface in domain:code \u2014 scope isolation takes precedence over user_edited flag",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": null,
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-composition-inheritance", "b-mongo-raw-driver"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
       "retrievalRecall": null,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 718.54
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-composition-inheritance",
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver"
+      ],
+      "retrievalLatencyMs": 69.94
     },
     {
       "caseId": "user-edited-absent-without-flag",
       "category": "Scope disambiguation",
       "description": "Non-user-edited writing belief does NOT cross into code scope pinnedFacts",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [
+        "b-ts-pref",
+        "b-composition-inheritance",
+        "b-mongo-raw-driver"
       ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": null,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
       "retrievalRecall": null,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 819.03
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-ts-pref",
+        "unexpected belief in relevantBeliefs: b-composition-inheritance",
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver"
+      ],
+      "retrievalLatencyMs": 80.59
     },
     {
       "caseId": "ranking-canonical-name-over-content",
       "category": "Ranking stability",
       "description": "canonical_name match (weight 10) outranks content-only match (weight 1) in relevantBeliefs ordering",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
-        "b-composition-inheritance"
+        "b-composition-inheritance",
+        "b-error-handling",
+        "b-mongo-raw-driver",
+        "b-ts-pref",
+        "b-fastify-pref",
+        "b-react-entity",
+        "b-sqlalchemy-superseded"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 1.0,
-      "retrievalRecall": 1.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.14285714285714285,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 1003.25
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-error-handling",
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-ts-pref",
+        "unexpected belief in relevantBeliefs: b-fastify-pref",
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded"
+      ],
+      "retrievalLatencyMs": 79.25
     },
     {
       "caseId": "messy-typo-blind-spot",
       "category": "Fuzzy matching and prefix guards",
       "description": "Typo 'typscript' does NOT match 'TypeScript' \u2014 documents text search limitation",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
-        "b-ts-pref"
+        "b-ts-pref",
+        "b-react-entity",
+        "b-mongo-raw-driver",
+        "b-error-handling",
+        "b-fastify-pref"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 1.0,
-      "retrievalRecall": 1.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.2,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 859.77
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-error-handling",
+        "unexpected belief in relevantBeliefs: b-fastify-pref"
+      ],
+      "retrievalLatencyMs": 72.56
     },
     {
       "caseId": "messy-all-caps-case-insensitive",
       "category": "Alias resolution",
       "description": "ALL-CAPS 'REACTJS' still resolves via case-insensitive text index",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [
+        "b-react-entity",
+        "b-error-handling",
+        "b-composition-inheritance",
+        "b-fastify-pref",
+        "b-ts-pref"
       ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.2,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
-        "missing expected belief: b-react-entity"
+        "unexpected belief in relevantBeliefs: b-error-handling",
+        "unexpected belief in relevantBeliefs: b-composition-inheritance",
+        "unexpected belief in relevantBeliefs: b-fastify-pref",
+        "unexpected belief in relevantBeliefs: b-ts-pref"
       ],
-      "retrievalLatencyMs": 1207.67
+      "retrievalLatencyMs": 66.88
     },
     {
       "caseId": "messy-filler-heavy-extraction",
       "category": "Alias resolution",
       "description": "Filler-heavy query \u2014 NLP extraction must cut through noise to find 'error handling'",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
-        "b-error-handling"
+        "b-error-handling",
+        "b-mongo-raw-driver",
+        "b-react-entity",
+        "b-composition-inheritance",
+        "b-sqlalchemy-superseded",
+        "b-fastify-pref"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 1.0,
-      "retrievalRecall": 1.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.16666666666666666,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 820.77
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-composition-inheritance",
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded",
+        "unexpected belief in relevantBeliefs: b-fastify-pref"
+      ],
+      "retrievalLatencyMs": 105.13
     },
     {
       "caseId": "messy-negation-surfaces-topic",
       "category": "Alias resolution",
       "description": "Negation 'I don't want class hierarchies' still surfaces the composition belief \u2014 text search has no semantic negation",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
-        "b-composition-inheritance"
+        "b-composition-inheritance",
+        "b-mongo-raw-driver",
+        "b-react-entity",
+        "b-sqlalchemy-superseded",
+        "b-error-handling",
+        "b-fastify-pref",
+        "b-ts-pref"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 1.0,
-      "retrievalRecall": 1.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.14285714285714285,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 1022.9
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded",
+        "unexpected belief in relevantBeliefs: b-error-handling",
+        "unexpected belief in relevantBeliefs: b-fastify-pref",
+        "unexpected belief in relevantBeliefs: b-ts-pref"
+      ],
+      "retrievalLatencyMs": 73.16
     },
     {
       "caseId": "messy-compound-surfaces-two-beliefs",
       "category": "Alias resolution",
       "description": "Single query spanning two topics surfaces both non-pinned beliefs",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-error-handling", "b-react-entity"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 1,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
-      "passed": false,
-      "failures": [
-        "missing expected belief: b-react-entity",
-        "missing expected belief: b-error-handling"
-      ],
-      "retrievalLatencyMs": 720.5
+      "passed": true,
+      "failures": [],
+      "retrievalLatencyMs": 69.09
     },
     {
       "caseId": "cap-stress-compound-six-entities",
       "category": "Alias resolution",
       "description": "Compound query mentions 6 entities \u2014 tests whether 12-token cap in buildSearchQuery drops non-pinned targets",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [
+        "b-react-entity",
+        "b-error-handling",
+        "b-kubernetes-entity",
+        "b-ts-pref",
+        "b-mongo-raw-driver",
+        "b-sqlalchemy-superseded"
       ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.8333333333333334,
+      "retrievalRecall": 0.8333333333333334,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
-        "missing expected belief: b-react-entity",
-        "missing expected belief: b-error-handling",
-        "missing expected belief: b-ci-gha-entity",
-        "missing expected belief: b-kubernetes-entity",
-        "missing expected belief: b-mongo-raw-driver",
-        "missing expected belief: b-ts-pref"
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded",
+        "missing expected belief: b-ci-gha-entity"
       ],
-      "retrievalLatencyMs": 718.41
+      "retrievalLatencyMs": 88.91
     },
     {
       "caseId": "cap-stress-kitchen-sink-exceeds-twelve",
       "category": "Alias resolution",
       "description": "Dense 8+ entity query that deliberately exceeds the 12-token cap \u2014 tests which non-pinned beliefs survive extraction truncation",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [
+        "b-react-entity",
+        "b-kubernetes-entity",
+        "b-ts-pref",
+        "b-error-handling",
+        "b-fastify-pref",
+        "b-mongo-raw-driver",
+        "b-composition-inheritance"
       ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.7142857142857143,
+      "retrievalRecall": 0.7142857142857143,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
-        "missing expected belief: b-react-entity",
-        "missing expected belief: b-error-handling",
+        "unexpected belief in relevantBeliefs: b-fastify-pref",
+        "unexpected belief in relevantBeliefs: b-composition-inheritance",
         "missing expected belief: b-ci-gha-entity",
-        "missing expected belief: b-kubernetes-entity",
-        "missing expected belief: b-mongo-raw-driver",
-        "missing expected belief: b-ts-pref",
         "missing expected belief: b-functional-pipeline"
       ],
-      "retrievalLatencyMs": 770.35
+      "retrievalLatencyMs": 96.27
     },
     {
       "caseId": "cap-stress-late-position-entity-at-risk",
       "category": "Alias resolution",
       "description": "Critical alias 'exceptions' appears after 6+ proper nouns \u2014 tests whether extraction order causes late-position tokens to fall past the 12-token cap",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [
+        "b-react-entity",
+        "b-error-handling",
+        "b-mongo-raw-driver",
+        "b-kubernetes-entity",
+        "b-sqlalchemy-superseded",
+        "b-ts-pref"
       ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.8333333333333334,
+      "retrievalRecall": 0.8333333333333334,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
-        "missing expected belief: b-ci-gha-entity",
-        "missing expected belief: b-react-entity",
-        "missing expected belief: b-kubernetes-entity",
-        "missing expected belief: b-mongo-raw-driver",
-        "missing expected belief: b-ts-pref",
-        "missing expected belief: b-error-handling"
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded",
+        "missing expected belief: b-ci-gha-entity"
       ],
-      "retrievalLatencyMs": 1170.12
+      "retrievalLatencyMs": 143.52
     },
     {
       "caseId": "fuzzy-single-edit-fires-non-pinned",
       "category": "Fuzzy matching and prefix guards",
       "description": "1-edit deletion 'eror' fuzzy-matches alias 'error' \u2014 prefix 'er' passes",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
-        "b-error-handling"
+        "b-error-handling",
+        "b-composition-inheritance",
+        "b-redis-code",
+        "b-mongo-raw-driver",
+        "b-fastify-pref",
+        "b-react-entity"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 1.0,
-      "retrievalRecall": 1.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.16666666666666666,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 895.12
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-composition-inheritance",
+        "unexpected belief in relevantBeliefs: b-redis-code",
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-fastify-pref",
+        "unexpected belief in relevantBeliefs: b-react-entity"
+      ],
+      "retrievalLatencyMs": 52.22
     },
     {
       "caseId": "fuzzy-scope-filter-discriminates-after-fuzzy-fires",
       "category": "Fuzzy matching and prefix guards",
       "description": "Typo 'Reedis' fuzzy-matches alias 'Redis' in both scopes \u2014 scope filter returns only code belief",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
-        "b-redis-code"
+        "b-redis-code",
+        "b-mongo-raw-driver",
+        "b-fastify-pref",
+        "b-sqlalchemy-superseded"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 1.0,
-      "retrievalRecall": 1.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.25,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 874.59
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-fastify-pref",
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded"
+      ],
+      "retrievalLatencyMs": 67.6
     },
     {
       "caseId": "fuzzy-prefix-blocks-transitive-match",
       "category": "Fuzzy matching and prefix guards",
       "description": "1-edit distance but prefix guard blocks \u2014 'mango' shares edit distance 1 with 'mongo' but 'ma' \u2260 'mo'",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [
+        "b-mongo-raw-driver",
+        "b-redis-code",
+        "b-kubernetes-entity"
       ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": null,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
       "retrievalRecall": null,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 792.17
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-redis-code",
+        "unexpected belief in relevantBeliefs: b-kubernetes-entity"
+      ],
+      "retrievalLatencyMs": 71.12
     },
     {
       "caseId": "fuzzy-abbreviation-prefix-blind-spot",
       "category": "Fuzzy matching and prefix guards",
       "description": "Alias 'k8s' \u2014 typo 'k9s' fails because prefix 'k9' \u2260 'k8' \u2014 single-char substitution in short aliases hits prefix guard",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": null,
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-kubernetes-entity"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
       "retrievalRecall": null,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 820.42
+      "passed": false,
+      "failures": ["unexpected belief in relevantBeliefs: b-kubernetes-entity"],
+      "retrievalLatencyMs": 55.84
     },
     {
       "caseId": "fuzzy-two-edit-transposition-blocked",
       "category": "Fuzzy matching and prefix guards",
       "description": "Transposition 'typsecript' IS matched by Atlas (Damerau-Levenshtein, 1 edit)",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
-        "b-ts-pref"
+        "b-ts-pref",
+        "b-react-entity",
+        "b-error-handling",
+        "b-fastify-pref",
+        "b-mongo-raw-driver"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 1.0,
-      "retrievalRecall": 1.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.2,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 918.13
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-error-handling",
+        "unexpected belief in relevantBeliefs: b-fastify-pref",
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver"
+      ],
+      "retrievalLatencyMs": 70.51
     },
     {
       "caseId": "fuzzy-single-term-only-signal",
       "category": "Fuzzy matching and prefix guards",
       "description": "Query is a single misspelled term \u2014 'mongod' is the only token, 1 edit from alias 'Mongo', prefix 'mo' passes",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-mongo-raw-driver", "b-sqlalchemy-superseded"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.5,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
-        "missing expected belief: b-mongo-raw-driver"
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded"
       ],
-      "retrievalLatencyMs": 919.99
+      "retrievalLatencyMs": 63.35
     },
     {
       "caseId": "universal-scope-belief-content-in-persona-prelude",
@@ -1109,103 +1102,96 @@
       "pinnedCoverage": null,
       "passed": true,
       "failures": [],
-      "retrievalLatencyMs": 717.45
+      "retrievalLatencyMs": 86.71
     },
     {
       "caseId": "type-isolation-open-question-not-in-relevant",
       "category": "Type routing and open questions",
       "description": "open_question belief with directly matched aliases must appear in openQuestions only \u2014 not in pinnedFacts or relevantBeliefs",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [
-        "b-auth-open-q"
-      ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-auth-open-q", "b-fastify-pref", "b-react-entity"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
       "retrievalRecall": null,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
-        "unexpected belief in relevantBeliefs: b-auth-open-q"
+        "unexpected belief in relevantBeliefs: b-auth-open-q",
+        "unexpected belief in relevantBeliefs: b-fastify-pref",
+        "unexpected belief in relevantBeliefs: b-react-entity"
       ],
-      "retrievalLatencyMs": 1027.84
+      "retrievalLatencyMs": 61.48
     },
     {
       "caseId": "multi-hop-supersession-chain-all-excluded",
       "category": "Supersession chain exclusion",
       "description": "Three-hop chain: TSLint (b-linting-v0) \u2192 ESLint (b-linting-v1) \u2192 Biome (b-linting-current). Query terms matching both superseded hops must surface neither; only the active terminal belief surfaces via pinnedFacts",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [
-        "b-linting-v0",
-        "b-linting-v1"
-      ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-ts-pref", "b-react-entity", "b-error-handling"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
       "retrievalRecall": null,
       "pinnedCoverage": 1,
       "passed": false,
       "failures": [
-        "unexpected belief in relevantBeliefs: b-linting-v0",
-        "unexpected belief in relevantBeliefs: b-linting-v1"
+        "unexpected belief in relevantBeliefs: b-ts-pref",
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-error-handling"
       ],
-      "retrievalLatencyMs": 837.16
+      "retrievalLatencyMs": 71.87
     },
     {
       "caseId": "cross-scope-one-empty-domain-does-not-degrade",
       "category": "Scope disambiguation",
       "description": "Multi-scope query where one scope (domain:hobby) has zero beliefs \u2014 code-scope retrieval must be unaffected and no empty-scope error must occur",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
         "b-redis-code",
-        "b-auth-depends-redis",
-        "b-auth-open-q"
+        "b-mongo-raw-driver",
+        "b-fastify-pref",
+        "b-react-entity",
+        "b-kubernetes-entity",
+        "b-sqlalchemy-superseded"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.3333333333333333,
-      "retrievalRecall": 1.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.16666666666666666,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
-        "unexpected belief in relevantBeliefs: b-auth-depends-redis",
-        "unexpected belief in relevantBeliefs: b-auth-open-q"
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-fastify-pref",
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-kubernetes-entity",
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded"
       ],
-      "retrievalLatencyMs": 899.22
+      "retrievalLatencyMs": 76.95
     },
     {
       "caseId": "ranking-orderedbefore-alias-beats-content",
       "category": "Ranking stability",
       "description": "Rare alias 'pipe' (high IDF, short field) outranks common alias 'error' \u2014 documents Atlas Search BM25 IDF weighting behavior",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
         "b-error-handling",
-        "b-functional-pipeline"
+        "b-mongo-raw-driver",
+        "b-composition-inheritance",
+        "b-ts-pref",
+        "b-sqlalchemy-superseded"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 1.0,
-      "retrievalRecall": 1.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.2,
+      "retrievalRecall": 0.5,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 1022.59
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-composition-inheritance",
+        "unexpected belief in relevantBeliefs: b-ts-pref",
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded",
+        "missing expected belief: b-functional-pipeline"
+      ],
+      "retrievalLatencyMs": 62.33
     },
     {
       "caseId": "cold-start-user-no-beliefs",
@@ -1219,7 +1205,7 @@
       "pinnedCoverage": null,
       "passed": true,
       "failures": [],
-      "retrievalLatencyMs": 715.3
+      "retrievalLatencyMs": 66.67
     },
     {
       "caseId": "narrator-voice-pinned-in-own-scope",
@@ -1231,15 +1217,13 @@
         "b-prose-style-user-edited"
       ],
       "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-chapter-structure-q"
-      ],
+      "retrievedQuestions": ["b-chapter-structure-q"],
       "retrievalPrecision": null,
       "retrievalRecall": null,
       "pinnedCoverage": 1,
       "passed": true,
       "failures": [],
-      "retrievalLatencyMs": 0.06
+      "retrievalLatencyMs": 0.07
     },
     {
       "caseId": "multi-scope-prelude-uses-primary-scope-only",
@@ -1252,89 +1236,342 @@
         "b-prose-style-user-edited",
         "b-linting-current"
       ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
+      "relevantBeliefs": [
+        "b-kubernetes-entity",
+        "b-fastify-pref",
         "b-auth-open-q",
-        "b-chapter-structure-q"
+        "b-react-entity"
       ],
-      "retrievalPrecision": null,
+      "retrievedQuestions": ["b-auth-open-q", "b-chapter-structure-q"],
+      "retrievalPrecision": 0,
       "retrievalRecall": null,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 720.03
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-kubernetes-entity",
+        "unexpected belief in relevantBeliefs: b-fastify-pref",
+        "unexpected belief in relevantBeliefs: b-auth-open-q",
+        "unexpected belief in relevantBeliefs: b-react-entity"
+      ],
+      "retrievalLatencyMs": 96.1
     },
     {
       "caseId": "why-it-matters-not-indexed-blind-spot",
       "category": "Design boundary cases",
       "description": "'Vue' appears only in b-react-entity.why_it_matters \u2014 not in canonical_name, aliases, or content. The query must not surface the belief.",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": null,
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-react-entity", "b-composition-inheritance"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
       "retrievalRecall": null,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 816.83
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-composition-inheritance"
+      ],
+      "retrievalLatencyMs": 104.28
     },
     {
       "caseId": "budget-ceiling-evicts-relevant-beliefs",
       "category": "Budget eviction and capacity",
       "description": "maxBeliefs set to exact pinned count \u2014 no slots remain for relevantBeliefs",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
+      "retrievedQuestions": ["b-auth-open-q"],
       "retrievalPrecision": null,
       "retrievalRecall": null,
       "pinnedCoverage": null,
       "passed": true,
       "failures": [],
-      "retrievalLatencyMs": 820.27
+      "retrievalLatencyMs": 83.59
     },
     {
       "caseId": "negative-guidance-mongoose",
       "category": "Counter-signal retrieval",
       "description": "Query for Mongoose schema surfaces b-mongo-raw-driver \u2014 the raw-driver preference is the counter-signal",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [
+        "b-mongo-raw-driver",
+        "b-sqlalchemy-superseded",
+        "b-auth-open-q",
+        "b-composition-inheritance",
+        "b-react-entity"
       ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.2,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
-        "missing expected belief: b-mongo-raw-driver"
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded",
+        "unexpected belief in relevantBeliefs: b-auth-open-q",
+        "unexpected belief in relevantBeliefs: b-composition-inheritance",
+        "unexpected belief in relevantBeliefs: b-react-entity"
       ],
-      "retrievalLatencyMs": 1228.91
+      "retrievalLatencyMs": 95.74
     },
     {
       "caseId": "recency-tiebreak-reinforcement",
       "category": "Ranking stability",
       "description": "Among equally-scored pinned beliefs, higher last_reinforced_at sorts first in pinnedFacts",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": null,
+      "retrievalRecall": null,
+      "pinnedCoverage": null,
+      "passed": true,
+      "failures": [],
+      "retrievalLatencyMs": 0.06
+    },
+    {
+      "caseId": "preference-flood-relevant-entity-survives",
+      "category": "Budget eviction and capacity",
+      "description": "Query about a specific entity is not drowned out by high-reinforcement preferences at budget ceiling",
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-auth-open-q", "b-kubernetes-entity"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
+      "retrievalRecall": 0,
+      "pinnedCoverage": null,
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-auth-open-q",
+        "unexpected belief in relevantBeliefs: b-kubernetes-entity",
+        "missing expected belief: b-ci-gha-entity"
       ],
+      "retrievalLatencyMs": 76.12
+    },
+    {
+      "caseId": "cross-scope-non-user-edited-blocked",
+      "category": "Scope disambiguation",
+      "description": "Writing-scope entity with strong name match does not surface in code-scope query",
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": null,
+      "retrievalRecall": null,
+      "pinnedCoverage": null,
+      "passed": true,
+      "failures": [],
+      "retrievalLatencyMs": 59.72
+    },
+    {
+      "caseId": "alias-two-word-shingle-dead-letter",
+      "category": "Alias resolution",
+      "description": "Two-word alias 'dead letter' fires via the shingle analyzer path on aliases.shingle multi-field",
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-error-handling"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
+      "retrievalRecall": 0,
+      "pinnedCoverage": null,
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-error-handling",
+        "missing expected belief: b-dead-letter-queue"
+      ],
+      "retrievalLatencyMs": 67.47
+    },
+    {
+      "caseId": "alias-dlq-abbreviation-resolves",
+      "category": "Alias resolution",
+      "description": "Alias 'DLQ' (abbreviation) drives text-search retrieval",
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-mongo-raw-driver"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
+      "retrievalRecall": 0,
+      "pinnedCoverage": null,
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "missing expected belief: b-dead-letter-queue"
+      ],
+      "retrievalLatencyMs": 69.41
+    },
+    {
+      "caseId": "counter-signal-jest-surfaces-vitest",
+      "category": "Counter-signal retrieval",
+      "description": "Counter-signal alias 'jest' on b-vitest-pref surfaces when user queries about Jest",
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [
+        "b-react-entity",
+        "b-ts-pref",
+        "b-mongo-raw-driver",
+        "b-error-handling",
+        "b-fastify-pref"
+      ],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
+      "retrievalRecall": 0,
+      "pinnedCoverage": null,
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-ts-pref",
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-error-handling",
+        "unexpected belief in relevantBeliefs: b-fastify-pref",
+        "missing expected belief: b-vitest-pref"
+      ],
+      "retrievalLatencyMs": 69.69
+    },
+    {
+      "caseId": "relation-type-expands-participants",
+      "category": "Relation expansion",
+      "description": "Relation belief 'auth depends on redis' surfaces via alias match AND pulls its participants (b-redis-code) into relevantBeliefs via one-hop join. b-auth-open-q goes to openQuestions since it's an open_question type.",
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [
+        "b-auth-open-q",
+        "b-error-handling",
+        "b-fastify-pref",
+        "b-kubernetes-entity",
+        "b-ts-pref"
+      ],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
+      "retrievalRecall": 0,
+      "pinnedCoverage": null,
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-auth-open-q",
+        "unexpected belief in relevantBeliefs: b-error-handling",
+        "unexpected belief in relevantBeliefs: b-fastify-pref",
+        "unexpected belief in relevantBeliefs: b-kubernetes-entity",
+        "unexpected belief in relevantBeliefs: b-ts-pref",
+        "missing expected belief: b-auth-depends-redis",
+        "missing expected belief: b-redis-code"
+      ],
+      "retrievalLatencyMs": 74.43
+    },
+    {
+      "caseId": "relation-participant-open-question-routes-correctly",
+      "category": "Relation expansion",
+      "description": "Participant b-auth-open-q is type=open_question and pinned. Even though it's pulled in via relation expansion, it must appear in openQuestions, not relevantBeliefs.",
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [
+        "b-auth-open-q",
+        "b-sqlalchemy-superseded",
+        "b-react-entity",
+        "b-redis-code",
+        "b-kubernetes-entity",
+        "b-mongo-raw-driver"
+      ],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.16666666666666666,
+      "retrievalRecall": 0.5,
+      "pinnedCoverage": null,
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-auth-open-q",
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded",
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-kubernetes-entity",
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "missing expected belief: b-auth-depends-redis"
+      ],
+      "retrievalLatencyMs": 67.45
+    },
+    {
+      "caseId": "relation-expansion-respects-scope-filter",
+      "category": "Relation expansion",
+      "description": "If a relation's participant is out of scope, it must NOT be pulled in by expansion. Hypothetical: b-auth-depends-redis has participant b-redis-writing (wrong scope). Scope filter in expandRelationParticipants blocks it.",
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-redis-code", "b-auth-open-q", "b-error-handling"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.3333333333333333,
+      "retrievalRecall": 0.5,
+      "pinnedCoverage": null,
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-auth-open-q",
+        "unexpected belief in relevantBeliefs: b-error-handling",
+        "missing expected belief: b-auth-depends-redis"
+      ],
+      "retrievalLatencyMs": 65.03
+    },
+    {
+      "caseId": "subtype-expertise-retrieval",
+      "category": "Type routing and open questions",
+      "description": "Subtype 'expertise' belief surfaces on a query about React skill calibration",
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [
+        "b-react-entity",
+        "b-composition-inheritance",
+        "b-error-handling"
+      ],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.3333333333333333,
+      "retrievalRecall": 1,
+      "pinnedCoverage": null,
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-composition-inheritance",
+        "unexpected belief in relevantBeliefs: b-error-handling"
+      ],
+      "retrievalLatencyMs": 79.34
+    },
+    {
+      "caseId": "pinned-plus-resolved-excluded-from-questions",
+      "category": "Type routing and open questions",
+      "description": "A belief that is both pinned AND has resolved_at set must NOT appear in openQuestions or pinnedFacts",
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [
+        "b-mongo-raw-driver",
+        "b-kubernetes-entity",
+        "b-fastify-pref",
+        "b-composition-inheritance",
+        "b-sqlalchemy-superseded",
+        "b-react-entity",
+        "b-auth-open-q",
+        "b-error-handling",
+        "b-redis-code"
+      ],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
+      "retrievalRecall": null,
+      "pinnedCoverage": null,
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-kubernetes-entity",
+        "unexpected belief in relevantBeliefs: b-fastify-pref",
+        "unexpected belief in relevantBeliefs: b-composition-inheritance",
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded",
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-auth-open-q",
+        "unexpected belief in relevantBeliefs: b-error-handling",
+        "unexpected belief in relevantBeliefs: b-redis-code"
+      ],
+      "retrievalLatencyMs": 66.03
+    },
+    {
+      "caseId": "zero-reinforcement-fresh-belief-surfaces",
+      "category": "Budget eviction and capacity",
+      "description": "Brand new belief with reinforcement_count: 0 still surfaces via alias match \u2014 recency/reinforcement must not suppress it",
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-kubernetes-entity", "b-composition-inheritance"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
+      "retrievalRecall": 0,
+      "pinnedCoverage": null,
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-kubernetes-entity",
+        "unexpected belief in relevantBeliefs: b-composition-inheritance",
+        "missing expected belief: b-zero-reinforcement-fresh"
+      ],
+      "retrievalLatencyMs": 68.94
+    },
+    {
+      "caseId": "budget-zero-graceful-empty",
+      "category": "Budget eviction and capacity",
+      "description": "maxBeliefs: 0 returns empty arrays without throwing",
+      "pinnedBeliefs": [],
+      "relevantBeliefs": [],
+      "retrievedQuestions": ["b-auth-open-q"],
       "retrievalPrecision": null,
       "retrievalRecall": null,
       "pinnedCoverage": null,
@@ -1343,281 +1580,18 @@
       "retrievalLatencyMs": 0.05
     },
     {
-      "caseId": "preference-flood-relevant-entity-survives",
-      "category": "Budget eviction and capacity",
-      "description": "Query about a specific entity is not drowned out by high-reinforcement preferences at budget ceiling",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
-      "pinnedCoverage": null,
-      "passed": false,
-      "failures": [
-        "missing expected belief: b-ci-gha-entity"
-      ],
-      "retrievalLatencyMs": 816.16
-    },
-    {
-      "caseId": "cross-scope-non-user-edited-blocked",
-      "category": "Scope disambiguation",
-      "description": "Writing-scope entity with strong name match does not surface in code-scope query",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": null,
-      "retrievalRecall": null,
-      "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 1014.29
-    },
-    {
-      "caseId": "alias-two-word-shingle-dead-letter",
-      "category": "Alias resolution",
-      "description": "Two-word alias 'dead letter' fires via the shingle analyzer path on aliases.shingle multi-field",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [
-        "b-dead-letter-queue"
-      ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 1.0,
-      "retrievalRecall": 1.0,
-      "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 830.09
-    },
-    {
-      "caseId": "alias-dlq-abbreviation-resolves",
-      "category": "Alias resolution",
-      "description": "Alias 'DLQ' (abbreviation) drives text-search retrieval",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
-      "pinnedCoverage": null,
-      "passed": false,
-      "failures": [
-        "missing expected belief: b-dead-letter-queue"
-      ],
-      "retrievalLatencyMs": 1028.51
-    },
-    {
-      "caseId": "counter-signal-jest-surfaces-vitest",
-      "category": "Counter-signal retrieval",
-      "description": "Counter-signal alias 'jest' on b-vitest-pref surfaces when user queries about Jest",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
-      "pinnedCoverage": null,
-      "passed": false,
-      "failures": [
-        "missing expected belief: b-vitest-pref"
-      ],
-      "retrievalLatencyMs": 652.86
-    },
-    {
-      "caseId": "relation-type-expands-participants",
-      "category": "Relation expansion",
-      "description": "Relation belief 'auth depends on redis' surfaces via alias match AND pulls its participants (b-redis-code) into relevantBeliefs via one-hop join. b-auth-open-q goes to openQuestions since it's an open_question type.",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [
-        "b-auth-depends-redis",
-        "b-redis-code",
-        "b-auth-open-q"
-      ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.6666666666666666,
-      "retrievalRecall": 1.0,
-      "pinnedCoverage": null,
-      "passed": false,
-      "failures": [
-        "unexpected belief in relevantBeliefs: b-auth-open-q"
-      ],
-      "retrievalLatencyMs": 980.56
-    },
-    {
-      "caseId": "relation-participant-open-question-routes-correctly",
-      "category": "Relation expansion",
-      "description": "Participant b-auth-open-q is type=open_question and pinned. Even though it's pulled in via relation expansion, it must appear in openQuestions, not relevantBeliefs.",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [
-        "b-auth-depends-redis",
-        "b-redis-code",
-        "b-auth-open-q"
-      ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.6666666666666666,
-      "retrievalRecall": 1.0,
-      "pinnedCoverage": null,
-      "passed": false,
-      "failures": [
-        "unexpected belief in relevantBeliefs: b-auth-open-q"
-      ],
-      "retrievalLatencyMs": 876.55
-    },
-    {
-      "caseId": "relation-expansion-respects-scope-filter",
-      "category": "Relation expansion",
-      "description": "If a relation's participant is out of scope, it must NOT be pulled in by expansion. Hypothetical: b-auth-depends-redis has participant b-redis-writing (wrong scope). Scope filter in expandRelationParticipants blocks it.",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [
-        "b-auth-depends-redis",
-        "b-redis-code",
-        "b-auth-open-q"
-      ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.6666666666666666,
-      "retrievalRecall": 1.0,
-      "pinnedCoverage": null,
-      "passed": false,
-      "failures": [
-        "unexpected belief in relevantBeliefs: b-auth-open-q"
-      ],
-      "retrievalLatencyMs": 1376.72
-    },
-    {
-      "caseId": "subtype-expertise-retrieval",
-      "category": "Type routing and open questions",
-      "description": "Subtype 'expertise' belief surfaces on a query about React skill calibration",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": 0.0,
-      "pinnedCoverage": null,
-      "passed": false,
-      "failures": [
-        "missing expected belief: b-react-entity"
-      ],
-      "retrievalLatencyMs": 817.45
-    },
-    {
-      "caseId": "pinned-plus-resolved-excluded-from-questions",
-      "category": "Type routing and open questions",
-      "description": "A belief that is both pinned AND has resolved_at set must NOT appear in openQuestions or pinnedFacts",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [
-        "b-pinned-resolved-interaction"
-      ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
-      "retrievalRecall": null,
-      "pinnedCoverage": null,
-      "passed": false,
-      "failures": [
-        "unexpected belief in relevantBeliefs: b-pinned-resolved-interaction"
-      ],
-      "retrievalLatencyMs": 1011.47
-    },
-    {
-      "caseId": "zero-reinforcement-fresh-belief-surfaces",
-      "category": "Budget eviction and capacity",
-      "description": "Brand new belief with reinforcement_count: 0 still surfaces via alias match \u2014 recency/reinforcement must not suppress it",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [
-        "b-zero-reinforcement-fresh"
-      ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 1.0,
-      "retrievalRecall": 1.0,
-      "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 849
-    },
-    {
-      "caseId": "budget-zero-graceful-empty",
-      "category": "Budget eviction and capacity",
-      "description": "maxBeliefs: 0 returns empty arrays without throwing",
-      "pinnedBeliefs": [],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": null,
-      "retrievalRecall": null,
-      "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 0.04
-    },
-    {
       "caseId": "budget-one-pinned-wins-over-relevant",
       "category": "Budget eviction and capacity",
       "description": "maxBeliefs: 1 with a query matching both a pinned belief and a non-pinned belief \u2014 pinned belief gets the slot",
-      "pinnedBeliefs": [
-        "b-db-decision"
-      ],
+      "pinnedBeliefs": ["b-db-decision"],
       "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
+      "retrievedQuestions": ["b-auth-open-q"],
       "retrievalPrecision": null,
       "retrievalRecall": null,
       "pinnedCoverage": 1,
       "passed": true,
       "failures": [],
-      "retrievalLatencyMs": 806.4
+      "retrievalLatencyMs": 68.55
     },
     {
       "caseId": "multi-scope-code-writing-dedup-no-double-surface",
@@ -1631,41 +1605,36 @@
         "b-linting-current"
       ],
       "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q",
-        "b-chapter-structure-q"
-      ],
+      "retrievedQuestions": ["b-auth-open-q", "b-chapter-structure-q"],
       "retrievalPrecision": null,
       "retrievalRecall": null,
       "pinnedCoverage": null,
       "passed": true,
       "failures": [],
-      "retrievalLatencyMs": 1035.14
+      "retrievalLatencyMs": 57.16
     },
     {
       "caseId": "empty-alias-belief-content-path-only",
       "category": "Design boundary cases",
       "description": "b-comm-recommendation has aliases: [] \u2014 can only be retrieved via content path. Since content is not a scored search path, it should NOT surface.",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": null,
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": ["b-mongo-raw-driver", "b-sqlalchemy-superseded"],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0,
       "retrievalRecall": null,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 1012.7
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded"
+      ],
+      "retrievalLatencyMs": 65.19
     },
     {
       "caseId": "universal-scope-explicit-query-no-relevant",
       "category": "Scope disambiguation",
       "description": "Query scoped explicitly to user:universal \u2014 universal beliefs appear in personaPrelude only, not in relevantBeliefs",
-      "pinnedBeliefs": [],
+      "pinnedBeliefs": ["b-comm-response-length", "b-comm-pushback"],
       "relevantBeliefs": [],
       "retrievedQuestions": [],
       "retrievalPrecision": null,
@@ -1673,84 +1642,227 @@
       "pinnedCoverage": null,
       "passed": true,
       "failures": [],
-      "retrievalLatencyMs": 549.42
+      "retrievalLatencyMs": 71.8
     },
     {
       "caseId": "negation-query-still-surfaces-rejected-tool",
       "category": "Design boundary cases",
       "description": "Query 'I do NOT want to use Express' still surfaces b-fastify-pref because text search has no negation awareness",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
-        "b-fastify-pref"
+        "b-fastify-pref",
+        "b-mongo-raw-driver",
+        "b-react-entity",
+        "b-auth-open-q",
+        "b-ts-pref",
+        "b-error-handling",
+        "b-composition-inheritance",
+        "b-sqlalchemy-superseded"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 1.0,
-      "retrievalRecall": 1.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.125,
+      "retrievalRecall": 1,
       "pinnedCoverage": null,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 1143.01
+      "passed": false,
+      "failures": [
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-auth-open-q",
+        "unexpected belief in relevantBeliefs: b-ts-pref",
+        "unexpected belief in relevantBeliefs: b-error-handling",
+        "unexpected belief in relevantBeliefs: b-composition-inheritance",
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded"
+      ],
+      "retrievalLatencyMs": 83.29
     },
     {
       "caseId": "superseded-chain-query-terminal-only",
       "category": "Supersession chain exclusion",
       "description": "Query 'TSLint' matches b-linting-v0 (superseded by v1, which is superseded by b-linting-current). Only terminal active belief surfaces.",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
-      "relevantBeliefs": [
-        "b-linting-v0",
-        "b-linting-v1"
-      ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.0,
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
+      "relevantBeliefs": [],
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": null,
       "retrievalRecall": null,
       "pinnedCoverage": 1,
-      "passed": false,
-      "failures": [
-        "unexpected belief in relevantBeliefs: b-linting-v0",
-        "unexpected belief in relevantBeliefs: b-linting-v1"
-      ],
-      "retrievalLatencyMs": 787.31
+      "passed": true,
+      "failures": [],
+      "retrievalLatencyMs": 63.16
     },
     {
       "caseId": "relation-does-not-appear-as-entity",
       "category": "Relation expansion",
       "description": "Relation-type belief does not bleed into pinnedFacts despite alias overlap with pinned beliefs",
-      "pinnedBeliefs": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefs": ["b-db-decision", "b-linting-current"],
       "relevantBeliefs": [
-        "b-auth-depends-redis",
         "b-redis-code",
-        "b-auth-open-q"
+        "b-sqlalchemy-superseded",
+        "b-react-entity",
+        "b-auth-open-q",
+        "b-kubernetes-entity",
+        "b-mongo-raw-driver"
       ],
-      "retrievedQuestions": [
-        "b-auth-open-q"
-      ],
-      "retrievalPrecision": 0.6666666666666666,
-      "retrievalRecall": 1.0,
+      "retrievedQuestions": ["b-auth-open-q"],
+      "retrievalPrecision": 0.16666666666666666,
+      "retrievalRecall": 0.5,
       "pinnedCoverage": null,
       "passed": false,
       "failures": [
-        "unexpected belief in relevantBeliefs: b-auth-open-q"
+        "unexpected belief in relevantBeliefs: b-sqlalchemy-superseded",
+        "unexpected belief in relevantBeliefs: b-react-entity",
+        "unexpected belief in relevantBeliefs: b-auth-open-q",
+        "unexpected belief in relevantBeliefs: b-kubernetes-entity",
+        "unexpected belief in relevantBeliefs: b-mongo-raw-driver",
+        "missing expected belief: b-auth-depends-redis"
       ],
-      "retrievalLatencyMs": 1102.02
+      "retrievalLatencyMs": 73.98
     }
   ],
   "ingestion": {
-    "beliefCount": 0,
-    "totalMs": 0,
-    "meanPerBeliefMs": 0,
-    "perBelief": []
+    "beliefCount": 35,
+    "totalMs": 5218.55,
+    "meanPerBeliefMs": 149.1,
+    "perBelief": [
+      {
+        "beliefId": "b-comm-response-length",
+        "latencyMs": 909.7
+      },
+      {
+        "beliefId": "b-comm-pushback",
+        "latencyMs": 341.78
+      },
+      {
+        "beliefId": "b-comm-recommendation",
+        "latencyMs": 135.14
+      },
+      {
+        "beliefId": "b-authorship-mode",
+        "latencyMs": 132.66
+      },
+      {
+        "beliefId": "b-ts-pref",
+        "latencyMs": 177.29
+      },
+      {
+        "beliefId": "b-fastify-pref",
+        "latencyMs": 96.55
+      },
+      {
+        "beliefId": "b-mongo-raw-driver",
+        "latencyMs": 117.06
+      },
+      {
+        "beliefId": "b-composition-inheritance",
+        "latencyMs": 95.41
+      },
+      {
+        "beliefId": "b-error-handling",
+        "latencyMs": 99.7
+      },
+      {
+        "beliefId": "b-db-decision",
+        "latencyMs": 49.59
+      },
+      {
+        "beliefId": "b-sqlalchemy-superseded",
+        "latencyMs": 94.51
+      },
+      {
+        "beliefId": "b-kubernetes-entity",
+        "latencyMs": 108.02
+      },
+      {
+        "beliefId": "b-react-entity",
+        "latencyMs": 302.25
+      },
+      {
+        "beliefId": "b-auth-open-q",
+        "latencyMs": 98.71
+      },
+      {
+        "beliefId": "b-narrator-voice",
+        "latencyMs": 99
+      },
+      {
+        "beliefId": "b-narrator-superseded",
+        "latencyMs": 108.32
+      },
+      {
+        "beliefId": "b-protagonist-entity",
+        "latencyMs": 119
+      },
+      {
+        "beliefId": "b-redis-writing",
+        "latencyMs": 120.64
+      },
+      {
+        "beliefId": "b-redis-code",
+        "latencyMs": 112.04
+      },
+      {
+        "beliefId": "b-chapter-structure-q",
+        "latencyMs": 93.36
+      },
+      {
+        "beliefId": "b-other-user-leak-check",
+        "latencyMs": 93.57
+      },
+      {
+        "beliefId": "b-ci-gha-entity",
+        "latencyMs": 100.27
+      },
+      {
+        "beliefId": "b-pov-shift-entity",
+        "latencyMs": 103.2
+      },
+      {
+        "beliefId": "b-hosting-resolved",
+        "latencyMs": 125.6
+      },
+      {
+        "beliefId": "b-prose-style-user-edited",
+        "latencyMs": 188.79
+      },
+      {
+        "beliefId": "b-functional-pipeline",
+        "latencyMs": 182.56
+      },
+      {
+        "beliefId": "b-linting-v0",
+        "latencyMs": 106.46
+      },
+      {
+        "beliefId": "b-linting-v1",
+        "latencyMs": 115.37
+      },
+      {
+        "beliefId": "b-linting-current",
+        "latencyMs": 106.49
+      },
+      {
+        "beliefId": "b-vitest-pref",
+        "latencyMs": 107
+      },
+      {
+        "beliefId": "b-dead-letter-queue",
+        "latencyMs": 114.87
+      },
+      {
+        "beliefId": "b-react-expertise",
+        "latencyMs": 98.79
+      },
+      {
+        "beliefId": "b-auth-depends-redis",
+        "latencyMs": 101.04
+      },
+      {
+        "beliefId": "b-pinned-resolved-interaction",
+        "latencyMs": 162.48
+      },
+      {
+        "beliefId": "b-zero-reinforcement-fresh",
+        "latencyMs": 101.33
+      }
+    ]
   }
 }

--- a/test-results/baseline/session-retrieval-report-supermemory.json
+++ b/test-results/baseline/session-retrieval-report-supermemory.json
@@ -1,18 +1,18 @@
 {
   "provider": "supermemory",
   "retrieval": {
-    "meanLatencyMs": 1014.08,
-    "p50LatencyMs": 867.83,
-    "p95LatencyMs": 1829.48,
+    "meanLatencyMs": 174.24,
+    "p50LatencyMs": 172.32,
+    "p95LatencyMs": 252.14,
     "caseCount": 2,
-    "meanPrecision": 0.6,
-    "meanRecall": 0.1667,
-    "totalPassed": 2,
+    "meanPrecision": 0.1825,
+    "meanRecall": 0.9091,
+    "totalPassed": 1,
     "totalCases": 12,
-    "passRate": 0.1667,
-    "activeRetrievalPasses": 1,
+    "passRate": 0.0833,
+    "activeRetrievalPasses": 0,
     "passTypes": {
-      "activeRetrieval": 1,
+      "activeRetrieval": 0,
       "structural": 0,
       "triviallyEmpty": 1
     },
@@ -20,10 +20,10 @@
       {
         "category": "Session-level noise isolation",
         "caseCount": 12,
-        "passed": 2,
-        "failed": 10,
-        "meanPrecision": 0.6,
-        "meanRecall": 0.1667
+        "passed": 1,
+        "failed": 11,
+        "meanPrecision": 0.1825,
+        "meanRecall": 0.9091
       }
     ],
     "turnCount": 12
@@ -34,40 +34,52 @@
       "category": "Session-level noise isolation",
       "turnIndex": 0,
       "label": "establishes_topic",
-      "retrievedBeliefIds": [],
-      "pinnedBeliefIds": [
-        "b-db-decision",
-        "b-linting-current"
+      "retrievedBeliefIds": [
+        "b-redis-code",
+        "b-pinned-resolved-interaction",
+        "b-dead-letter-queue"
       ],
+      "pinnedBeliefIds": ["b-db-decision", "b-linting-current"],
       "noiseBeliefIds": [],
-      "driftScore": 0,
+      "driftScore": 0.6666666666666667,
       "passed": false,
       "failures": [
-        "turn 0: missing expected belief: b-redis-code"
+        "turn 0: unexpected relevant belief: b-pinned-resolved-interaction",
+        "turn 0: unexpected relevant belief: b-dead-letter-queue"
       ],
-      "retrievalLatencyMs": 1829.48,
-      "retrievalPrecision": null,
-      "retrievalRecall": 0
+      "retrievalLatencyMs": 186.73,
+      "retrievalPrecision": 0.3333333333333333,
+      "retrievalRecall": 1
     },
     {
       "caseId": "session-drift-noise-10-turns-implicit-redis",
       "category": "Session-level noise isolation",
       "turnIndex": 1,
       "label": "drift",
-      "retrievedBeliefIds": [],
-      "pinnedBeliefIds": [
-        "b-db-decision",
-        "b-linting-current"
+      "retrievedBeliefIds": [
+        "b-kubernetes-entity",
+        "b-hosting-resolved",
+        "b-pinned-resolved-interaction",
+        "b-dead-letter-queue",
+        "b-vitest-pref",
+        "b-redis-code",
+        "b-ci-gha-entity"
       ],
+      "pinnedBeliefIds": ["b-db-decision", "b-linting-current"],
       "noiseBeliefIds": [],
-      "driftScore": 0,
+      "driftScore": 0.8571428571428572,
       "passed": false,
       "failures": [
-        "turn 1: missing expected belief: b-kubernetes-entity"
+        "turn 1: unexpected relevant belief: b-hosting-resolved",
+        "turn 1: unexpected relevant belief: b-pinned-resolved-interaction",
+        "turn 1: unexpected relevant belief: b-dead-letter-queue",
+        "turn 1: unexpected relevant belief: b-vitest-pref",
+        "turn 1: unexpected relevant belief: b-redis-code",
+        "turn 1: unexpected relevant belief: b-ci-gha-entity"
       ],
-      "retrievalLatencyMs": 1021.14,
-      "retrievalPrecision": null,
-      "retrievalRecall": 0
+      "retrievalLatencyMs": 172.32,
+      "retrievalPrecision": 0.14285714285714285,
+      "retrievalRecall": 1
     },
     {
       "caseId": "session-drift-noise-10-turns-implicit-redis",
@@ -75,18 +87,32 @@
       "turnIndex": 2,
       "label": "drift",
       "retrievedBeliefIds": [
-        "b-react-entity"
+        "b-react-entity",
+        "b-kubernetes-entity",
+        "b-hosting-resolved",
+        "b-auth-open-q",
+        "b-pinned-resolved-interaction",
+        "b-vitest-pref",
+        "b-redis-code",
+        "b-auth-depends-redis",
+        "b-dead-letter-queue"
       ],
-      "pinnedBeliefIds": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefIds": ["b-db-decision", "b-linting-current"],
       "noiseBeliefIds": [],
-      "driftScore": 0,
-      "passed": true,
-      "failures": [],
-      "retrievalLatencyMs": 821.23,
-      "retrievalPrecision": 1,
+      "driftScore": 0.8888888888888888,
+      "passed": false,
+      "failures": [
+        "turn 2: unexpected relevant belief: b-kubernetes-entity",
+        "turn 2: unexpected relevant belief: b-hosting-resolved",
+        "turn 2: unexpected relevant belief: b-auth-open-q",
+        "turn 2: unexpected relevant belief: b-pinned-resolved-interaction",
+        "turn 2: unexpected relevant belief: b-vitest-pref",
+        "turn 2: unexpected relevant belief: b-redis-code",
+        "turn 2: unexpected relevant belief: b-auth-depends-redis",
+        "turn 2: unexpected relevant belief: b-dead-letter-queue"
+      ],
+      "retrievalLatencyMs": 233.17,
+      "retrievalPrecision": 0.1111111111111111,
       "retrievalRecall": 1
     },
     {
@@ -95,42 +121,67 @@
       "turnIndex": 3,
       "label": "drift",
       "retrievedBeliefIds": [
-        "b-error-handling"
+        "b-error-handling",
+        "b-fastify-pref",
+        "b-linting-v0",
+        "b-functional-pipeline",
+        "b-linting-v1",
+        "b-composition-inheritance",
+        "b-mongo-raw-driver",
+        "b-ts-pref",
+        "b-react-entity"
       ],
-      "pinnedBeliefIds": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefIds": ["b-db-decision", "b-linting-current"],
       "noiseBeliefIds": [],
-      "driftScore": 0,
+      "driftScore": 0.6666666666666667,
       "passed": false,
       "failures": [
-        "turn 3: missing expected belief: b-ts-pref",
-        "turn 3: missing expected belief: b-fastify-pref"
+        "turn 3: unexpected relevant belief: b-linting-v0",
+        "turn 3: unexpected relevant belief: b-functional-pipeline",
+        "turn 3: unexpected relevant belief: b-linting-v1",
+        "turn 3: unexpected relevant belief: b-composition-inheritance",
+        "turn 3: unexpected relevant belief: b-mongo-raw-driver",
+        "turn 3: unexpected relevant belief: b-react-entity"
       ],
-      "retrievalLatencyMs": 1376.26,
-      "retrievalPrecision": 1,
-      "retrievalRecall": 0.3333333333333333
+      "retrievalLatencyMs": 185.18,
+      "retrievalPrecision": 0.3333333333333333,
+      "retrievalRecall": 1
     },
     {
       "caseId": "session-drift-noise-10-turns-implicit-redis",
       "category": "Session-level noise isolation",
       "turnIndex": 4,
       "label": "drift",
-      "retrievedBeliefIds": [],
-      "pinnedBeliefIds": [
-        "b-db-decision",
-        "b-linting-current"
+      "retrievedBeliefIds": [
+        "b-ci-gha-entity",
+        "b-vitest-pref",
+        "b-pinned-resolved-interaction",
+        "b-kubernetes-entity",
+        "b-functional-pipeline",
+        "b-react-entity",
+        "b-hosting-resolved",
+        "b-fastify-pref",
+        "b-auth-open-q",
+        "b-redis-code"
       ],
+      "pinnedBeliefIds": ["b-db-decision", "b-linting-current"],
       "noiseBeliefIds": [],
-      "driftScore": 0,
+      "driftScore": 0.9,
       "passed": false,
       "failures": [
-        "turn 4: missing expected belief: b-ci-gha-entity"
+        "turn 4: unexpected relevant belief: b-vitest-pref",
+        "turn 4: unexpected relevant belief: b-pinned-resolved-interaction",
+        "turn 4: unexpected relevant belief: b-kubernetes-entity",
+        "turn 4: unexpected relevant belief: b-functional-pipeline",
+        "turn 4: unexpected relevant belief: b-react-entity",
+        "turn 4: unexpected relevant belief: b-hosting-resolved",
+        "turn 4: unexpected relevant belief: b-fastify-pref",
+        "turn 4: unexpected relevant belief: b-auth-open-q",
+        "turn 4: unexpected relevant belief: b-redis-code"
       ],
-      "retrievalLatencyMs": 808.73,
-      "retrievalPrecision": null,
-      "retrievalRecall": 0
+      "retrievalLatencyMs": 172.05,
+      "retrievalPrecision": 0.1,
+      "retrievalRecall": 1
     },
     {
       "caseId": "session-drift-noise-10-turns-implicit-redis",
@@ -138,23 +189,32 @@
       "turnIndex": 5,
       "label": "drift",
       "retrievedBeliefIds": [
-        "b-auth-open-q"
+        "b-auth-open-q",
+        "b-hosting-resolved",
+        "b-auth-depends-redis",
+        "b-pinned-resolved-interaction",
+        "b-fastify-pref",
+        "b-react-entity",
+        "b-mongo-raw-driver",
+        "b-sqlalchemy-superseded",
+        "b-redis-code"
       ],
-      "pinnedBeliefIds": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefIds": ["b-db-decision", "b-linting-current"],
       "noiseBeliefIds": [],
-      "driftScore": 1,
+      "driftScore": 0.7777777777777778,
       "passed": false,
       "failures": [
         "turn 5: unexpected relevant belief: b-auth-open-q",
-        "turn 5: missing expected belief: b-auth-depends-redis",
-        "turn 5: missing expected belief: b-redis-code"
+        "turn 5: unexpected relevant belief: b-hosting-resolved",
+        "turn 5: unexpected relevant belief: b-pinned-resolved-interaction",
+        "turn 5: unexpected relevant belief: b-fastify-pref",
+        "turn 5: unexpected relevant belief: b-react-entity",
+        "turn 5: unexpected relevant belief: b-mongo-raw-driver",
+        "turn 5: unexpected relevant belief: b-sqlalchemy-superseded"
       ],
-      "retrievalLatencyMs": 858.94,
-      "retrievalPrecision": 0,
-      "retrievalRecall": 0
+      "retrievalLatencyMs": 252.14,
+      "retrievalPrecision": 0.2222222222222222,
+      "retrievalRecall": 1
     },
     {
       "caseId": "session-drift-noise-10-turns-implicit-redis",
@@ -162,21 +222,30 @@
       "turnIndex": 6,
       "label": "drift",
       "retrievedBeliefIds": [
-        "b-functional-pipeline"
+        "b-functional-pipeline",
+        "b-mongo-raw-driver",
+        "b-pinned-resolved-interaction",
+        "b-sqlalchemy-superseded",
+        "b-fastify-pref",
+        "b-ci-gha-entity",
+        "b-composition-inheritance",
+        "b-react-entity"
       ],
-      "pinnedBeliefIds": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefIds": ["b-db-decision", "b-linting-current"],
       "noiseBeliefIds": [],
-      "driftScore": 0,
+      "driftScore": 0.75,
       "passed": false,
       "failures": [
-        "turn 6: missing expected belief: b-mongo-raw-driver"
+        "turn 6: unexpected relevant belief: b-pinned-resolved-interaction",
+        "turn 6: unexpected relevant belief: b-sqlalchemy-superseded",
+        "turn 6: unexpected relevant belief: b-fastify-pref",
+        "turn 6: unexpected relevant belief: b-ci-gha-entity",
+        "turn 6: unexpected relevant belief: b-composition-inheritance",
+        "turn 6: unexpected relevant belief: b-react-entity"
       ],
-      "retrievalLatencyMs": 896.83,
-      "retrievalPrecision": 1,
-      "retrievalRecall": 0.5
+      "retrievalLatencyMs": 220.62,
+      "retrievalPrecision": 0.25,
+      "retrievalRecall": 1
     },
     {
       "caseId": "session-drift-noise-10-turns-implicit-redis",
@@ -184,43 +253,76 @@
       "turnIndex": 7,
       "label": "drift",
       "retrievedBeliefIds": [
-        "b-linting-v1"
+        "b-ts-pref",
+        "b-mongo-raw-driver",
+        "b-linting-v0",
+        "b-linting-v1",
+        "b-sqlalchemy-superseded",
+        "b-vitest-pref",
+        "b-hosting-resolved",
+        "b-fastify-pref",
+        "b-error-handling",
+        "b-functional-pipeline",
+        "b-pinned-resolved-interaction"
       ],
-      "pinnedBeliefIds": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefIds": ["b-db-decision", "b-linting-current"],
       "noiseBeliefIds": [],
-      "driftScore": 1,
+      "driftScore": 0.8181818181818181,
       "passed": false,
       "failures": [
+        "turn 7: unexpected relevant belief: b-mongo-raw-driver",
+        "turn 7: unexpected relevant belief: b-linting-v0",
         "turn 7: unexpected relevant belief: b-linting-v1",
-        "turn 7: missing expected belief: b-ts-pref",
-        "turn 7: missing expected belief: b-error-handling"
+        "turn 7: unexpected relevant belief: b-sqlalchemy-superseded",
+        "turn 7: unexpected relevant belief: b-vitest-pref",
+        "turn 7: unexpected relevant belief: b-hosting-resolved",
+        "turn 7: unexpected relevant belief: b-fastify-pref",
+        "turn 7: unexpected relevant belief: b-functional-pipeline",
+        "turn 7: unexpected relevant belief: b-pinned-resolved-interaction"
       ],
-      "retrievalLatencyMs": 981.78,
-      "retrievalPrecision": 0,
-      "retrievalRecall": 0
+      "retrievalLatencyMs": 206.24,
+      "retrievalPrecision": 0.18181818181818182,
+      "retrievalRecall": 1
     },
     {
       "caseId": "session-drift-noise-10-turns-implicit-redis",
       "category": "Session-level noise isolation",
       "turnIndex": 8,
       "label": "drift",
-      "retrievedBeliefIds": [],
-      "pinnedBeliefIds": [
-        "b-db-decision",
-        "b-linting-current"
+      "retrievedBeliefIds": [
+        "b-mongo-raw-driver",
+        "b-composition-inheritance",
+        "b-functional-pipeline",
+        "b-sqlalchemy-superseded",
+        "b-pinned-resolved-interaction",
+        "b-ci-gha-entity",
+        "b-vitest-pref",
+        "b-react-entity",
+        "b-linting-v0",
+        "b-linting-v1",
+        "b-dead-letter-queue",
+        "b-error-handling"
       ],
+      "pinnedBeliefIds": ["b-db-decision", "b-linting-current"],
       "noiseBeliefIds": [],
-      "driftScore": 0,
+      "driftScore": 0.9166666666666666,
       "passed": false,
       "failures": [
-        "turn 8: missing expected belief: b-composition-inheritance"
+        "turn 8: unexpected relevant belief: b-mongo-raw-driver",
+        "turn 8: unexpected relevant belief: b-functional-pipeline",
+        "turn 8: unexpected relevant belief: b-sqlalchemy-superseded",
+        "turn 8: unexpected relevant belief: b-pinned-resolved-interaction",
+        "turn 8: unexpected relevant belief: b-ci-gha-entity",
+        "turn 8: unexpected relevant belief: b-vitest-pref",
+        "turn 8: unexpected relevant belief: b-react-entity",
+        "turn 8: unexpected relevant belief: b-linting-v0",
+        "turn 8: unexpected relevant belief: b-linting-v1",
+        "turn 8: unexpected relevant belief: b-dead-letter-queue",
+        "turn 8: unexpected relevant belief: b-error-handling"
       ],
-      "retrievalLatencyMs": 867.83,
-      "retrievalPrecision": null,
-      "retrievalRecall": 0
+      "retrievalLatencyMs": 139.96,
+      "retrievalPrecision": 0.08333333333333333,
+      "retrievalRecall": 1
     },
     {
       "caseId": "session-drift-noise-10-turns-implicit-redis",
@@ -228,15 +330,12 @@
       "turnIndex": 9,
       "label": "implicit_continuation",
       "retrievedBeliefIds": [],
-      "pinnedBeliefIds": [
-        "b-db-decision",
-        "b-linting-current"
-      ],
+      "pinnedBeliefIds": ["b-db-decision", "b-linting-current"],
       "noiseBeliefIds": [],
       "driftScore": 0,
       "passed": true,
       "failures": [],
-      "retrievalLatencyMs": 1065.72,
+      "retrievalLatencyMs": 60.89,
       "retrievalPrecision": null,
       "retrievalRecall": null
     },
@@ -245,19 +344,36 @@
       "category": "Session-level noise isolation",
       "turnIndex": 10,
       "label": "re_entry",
-      "retrievedBeliefIds": [],
-      "pinnedBeliefIds": [
-        "b-db-decision",
-        "b-linting-current"
+      "retrievedBeliefIds": [
+        "b-pinned-resolved-interaction",
+        "b-kubernetes-entity",
+        "b-sqlalchemy-superseded",
+        "b-ci-gha-entity",
+        "b-auth-open-q",
+        "b-composition-inheritance"
       ],
-      "noiseBeliefIds": [],
-      "driftScore": 0,
+      "pinnedBeliefIds": ["b-db-decision", "b-linting-current"],
+      "noiseBeliefIds": [
+        "b-kubernetes-entity",
+        "b-ci-gha-entity",
+        "b-composition-inheritance"
+      ],
+      "driftScore": 1,
       "passed": false,
       "failures": [
-        "turn 10: missing expected belief: b-redis-code"
+        "turn 10: unexpected relevant belief: b-pinned-resolved-interaction",
+        "turn 10: unexpected relevant belief: b-kubernetes-entity",
+        "turn 10: unexpected relevant belief: b-sqlalchemy-superseded",
+        "turn 10: unexpected relevant belief: b-ci-gha-entity",
+        "turn 10: unexpected relevant belief: b-auth-open-q",
+        "turn 10: unexpected relevant belief: b-composition-inheritance",
+        "turn 10: missing expected belief: b-redis-code",
+        "turn 10: noise belief surfaced: b-kubernetes-entity",
+        "turn 10: noise belief surfaced: b-ci-gha-entity",
+        "turn 10: noise belief surfaced: b-composition-inheritance"
       ],
-      "retrievalLatencyMs": 818.32,
-      "retrievalPrecision": null,
+      "retrievalLatencyMs": 127.73,
+      "retrievalPrecision": 0,
       "retrievalRecall": 0
     },
     {
@@ -265,20 +381,24 @@
       "category": "Session-level noise isolation",
       "turnIndex": 0,
       "label": "implicit_continuation",
-      "retrievedBeliefIds": [],
-      "pinnedBeliefIds": [
-        "b-db-decision",
-        "b-linting-current"
+      "retrievedBeliefIds": [
+        "b-kubernetes-entity",
+        "b-sqlalchemy-superseded",
+        "b-redis-code",
+        "b-pinned-resolved-interaction"
       ],
+      "pinnedBeliefIds": ["b-db-decision", "b-linting-current"],
       "noiseBeliefIds": [],
-      "driftScore": 0,
+      "driftScore": 0.75,
       "passed": false,
       "failures": [
-        "turn 0: missing expected belief: b-redis-code"
+        "turn 0: unexpected relevant belief: b-kubernetes-entity",
+        "turn 0: unexpected relevant belief: b-sqlalchemy-superseded",
+        "turn 0: unexpected relevant belief: b-pinned-resolved-interaction"
       ],
-      "retrievalLatencyMs": 822.68,
-      "retrievalPrecision": null,
-      "retrievalRecall": 0
+      "retrievalLatencyMs": 133.79,
+      "retrievalPrecision": 0.25,
+      "retrievalRecall": 1
     }
   ]
 }

--- a/wrappers/supermemory/Dockerfile
+++ b/wrappers/supermemory/Dockerfile
@@ -1,20 +1,34 @@
-FROM python:3.12-slim
+FROM ubuntu:26.04 AS binary
 
+ENV SUPERMEMORY_BINARY_URL="https://github.com/supermemoryai/supermemory/releases/download/server-v0.0.3/supermemory-server-linux-x64"
+ENV SUPERMEMORY_BINARY_SHA256="4036486514bd3511099e8f8642e1c56ecc58550c5e194442e88a5438992c0957"
+
+RUN apt-get update \
+    && apt-get install -y curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL "$SUPERMEMORY_BINARY_URL" -o /tmp/supermemory-server \
+    && echo "$SUPERMEMORY_BINARY_SHA256  /tmp/supermemory-server" | sha256sum -c - \
+    && chmod +x /tmp/supermemory-server
+
+FROM ubuntu:26.04 AS runtime
 WORKDIR /app
 
-RUN pip install --no-cache-dir \
-    fastapi==0.115.12 \
-    uvicorn[standard]==0.34.2 \
-    httpx==0.28.1 \
-    pydantic==2.11.4
+RUN apt-get update \
+    && apt-get install -y python3 curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
+
+COPY --from=binary /tmp/supermemory-server /usr/local/bin/supermemory-server
+
+RUN uv init --bare
+RUN uv add fastapi==0.138.1 uvicorn==0.49.0 httpx==0.28.1
 
 COPY supermemory_service.py .
 
-ENV SUPERMEMORY_API_KEY=""
-ENV SEED_DELAY_MS=0
-ENV POLL_TIMEOUT_S=30
-ENV PORT=8080
-
-EXPOSE 8080
-
-CMD ["python", "supermemory_service.py"]
+CMD supermemory-server & \
+    until [ -f ./.supermemory/auth-secret ]; do sleep 0.5; done && \
+    export SUPERMEMORY_API_KEY=$(cat ./.supermemory/auth-secret) && \
+    uv run uvicorn supermemory_service:app --host 0.0.0.0 --port 8080

--- a/wrappers/supermemory/README.md
+++ b/wrappers/supermemory/README.md
@@ -1,0 +1,42 @@
+## Reproducibility
+
+Supermemory local is distributed as a compiled binary. PrecisionMemBench packages that binary into a Docker image and pins the resulting image by digest.
+
+Benchmark image:
+
+```bash
+docker pull tenurehq/precisionmembench-supermemory@sha256:<digest>
+```
+
+## Evaluated artifact
+
+| Field                        | Value                                                                     |
+| ---------------------------- | ------------------------------------------------------------------------- |
+| Provider                     | `supermemory`                                                             |
+| Distribution                 | Local/self-hosted compiled binary                                         |
+| Supermemory version          | `v0.0.3`                                                                  |
+| Binary filename              | `supermemory-server`                                                      |
+| Binary digest                | `sha256:4036486514bd3511099e8f8642e1c56ecc58550c5e194442e88a5438992c0957` |
+| Binary digest source         | Release manifest                                                          |
+| Docker image                 | `tenurehq/precisionmembench-supermemory`                                  |
+| Docker image digest          | `sha256:<image-digest>`                                                   |
+| Built on                     | `2026-06-25`                                                              |
+| Retrieval threshold override | None                                                                      |
+
+## Running the Supermemory eval
+
+The Supermemory local binary is packaged into the published Docker image used by PrecisionMemBench. The wrapper source is included in this directory for transparency, so reviewers can inspect the `/add`, `/search`, and `/reset` adapter logic. The benchmark run itself should use the pinned Docker image, not a locally modified wrapper.
+
+To reproduce the published run:
+
+```bash
+cd wrappers/supermemory
+docker compose up
+```
+
+In a second terminal, from the repository root:
+
+```bash
+MEMORY_PROVIDER=supermemory RESEED=true npx ava src/retrieval.external.eval.test.ts --timeout 10m
+MEMORY_PROVIDER=supermemory npx ava src/session-retrieval.external.eval.test.ts --timeout 10m
+```

--- a/wrappers/supermemory/docker-compose.yml
+++ b/wrappers/supermemory/docker-compose.yml
@@ -1,10 +1,12 @@
 services:
   supermemory:
-    build: .
+    image: tenurehq/precisionmembench-supermemory@sha256:b4ef936e7b03bea8882d590bd2ab91097c74e155695675a48a1b1baab33e17e5
     ports:
       - "8080:8080"
     environment:
-      SUPERMEMORY_API_KEY: INSERT_KEY_HERE
+      OPENAI_API_KEY: ""
+      OPENAI_BASE_URL: ""
+      OPENAI_MODEL: ""
       POLL_TIMEOUT_S: "30"
       SEED_DELAY_MS: "0"
       PORT: "8080"

--- a/wrappers/supermemory/supermemory_service.py
+++ b/wrappers/supermemory/supermemory_service.py
@@ -1,17 +1,11 @@
 """
-supermemory_service.py — PrecisionMemBench wrapper for Supermemory
+supermemory_service.py - PrecisionMemBench wrapper for Supermemory
 Implements the three-endpoint contract on port 8080:
-  POST   /add     — ingest a belief
-  POST   /search  — retrieve beliefs by query
-  DELETE /reset   — wipe all stored beliefs
-
-Supermemory API mapping:
-  /add    → POST   https://api.supermemory.ai/v3/documents
-  /search → POST   https://api.supermemory.ai/v4/search
-  /reset  → POST   https://api.supermemory.ai/v3/settings/reset
+  POST   /add     - ingest a belief
+  POST   /search  - retrieve beliefs by query
+  DELETE /reset   - wipe all stored beliefs
 
 Environment variables:
-  SUPERMEMORY_API_KEY   required — API key from console.supermemory.ai
   SEED_DELAY_MS         extra wait after /add  (default: 0)
   POLL_TIMEOUT_S        max seconds to poll    (default: 30)
   PORT                  HTTP port              (default: 8080)
@@ -32,32 +26,34 @@ logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("supermemory_service")
 
 
-API_KEY = os.environ["SUPERMEMORY_API_KEY"]         
-BASE_URL = "https://api.supermemory.ai"
+BASE_URL = "http://localhost:6767"
 SEED_DELAY_MS = int(os.getenv("SEED_DELAY_MS", "0"))
 POLL_TIMEOUT_S = int(os.getenv("POLL_TIMEOUT_S", "30"))
 PORT = int(os.getenv("PORT", "8080"))
 
+SUPERMEMORY_API_KEY = os.getenv("SUPERMEMORY_API_KEY", "")
 HEADERS = {
-    "Authorization": f"Bearer {API_KEY}",
+    "Authorization": f"Bearer {SUPERMEMORY_API_KEY}",
     "Content-Type": "application/json",
 }
 
 app = FastAPI(title="supermemory-bench-wrapper")
 
 
-
 class Metadata(BaseModel):
     beliefId: str
     scope: str
+
 
 class AddRequest(BaseModel):
     text: str
     user_id: str
     metadata: Metadata
 
+
 class AddResponse(BaseModel):
     ok: bool
+
 
 class SearchRequest(BaseModel):
     query: str
@@ -65,13 +61,16 @@ class SearchRequest(BaseModel):
     limit: int = 20
     scope: str
 
+
 class SearchResult(BaseModel):
-    id: str        
+    id: str
     memory: str
     score: float
 
+
 class SearchResponse(BaseModel):
     results: list[SearchResult]
+
 
 class ResetResponse(BaseModel):
     ok: bool
@@ -100,7 +99,6 @@ async def _poll_until_ready(client: httpx.AsyncClient, doc_id: str) -> None:
     log.warning("Poll timeout for doc %s after %ss", doc_id, POLL_TIMEOUT_S)
 
 
-
 @app.post("/add", response_model=AddResponse)
 async def add(req: AddRequest):
     """
@@ -115,7 +113,7 @@ async def add(req: AddRequest):
         "content": req.text,
         "containerTag": req.user_id,
         "metadata": {"beliefId": belief_id, "scope": req.metadata.scope},
-        "filterByMetadata": {"scope": req.metadata.scope}
+        "filterByMetadata": {"scope": req.metadata.scope},
     }
     if belief_id:
         payload["customId"] = belief_id
@@ -130,7 +128,9 @@ async def add(req: AddRequest):
             )
             r.raise_for_status()
         except httpx.HTTPStatusError as exc:
-            log.error("add failed: %s — %s", exc.response.status_code, exc.response.text)
+            log.error(
+                "add failed: %s - %s", exc.response.status_code, exc.response.text
+            )
             raise HTTPException(status_code=502, detail=exc.response.text) from exc
 
         doc_id = r.json().get("id", "")
@@ -150,21 +150,14 @@ async def search(req: SearchRequest):
     Search Supermemory for beliefs matching the query.
 
     We use searchMode='memories' (not hybrid) so results are purely the
-    extracted memory entries — the same unit the benchmark scored on ingest.
-
-    threshold=0.0 returns all results ranked by similarity; the harness
-    already handles precision by checking which beliefIds are present,
-    so we don't want the API to pre-filter based on score.
+    extracted memory entries - the same unit the benchmark scored on ingest.
     """
     payload: dict[str, Any] = {
         "q": req.query,
         "containerTag": req.user_id,
         "limit": req.limit,
         "searchMode": "memories",
-        "threshold": 0.69,
-        "filters": {
-        "AND": [{"key": "scope", "value": req.scope}]
-        }
+        "filters": {"AND": [{"key": "scope", "value": req.scope}]},
     }
 
     async with httpx.AsyncClient() as client:
@@ -177,7 +170,9 @@ async def search(req: SearchRequest):
             )
             r.raise_for_status()
         except httpx.HTTPStatusError as exc:
-            log.error("search failed: %s — %s", exc.response.status_code, exc.response.text)
+            log.error(
+                "search failed: %s - %s", exc.response.status_code, exc.response.text
+            )
             raise HTTPException(status_code=502, detail=exc.response.text) from exc
 
     raw = r.json().get("results", [])
@@ -194,7 +189,7 @@ async def search(req: SearchRequest):
 @app.delete("/reset", response_model=ResetResponse)
 async def reset():
     """
-    Wipe all data in the Supermemory organisation.
+    Wipe all data in the Supermemory organization.
     POST /v3/settings/reset requires a `confirmation` string.
     """
     async with httpx.AsyncClient() as client:
@@ -207,12 +202,13 @@ async def reset():
             )
             r.raise_for_status()
         except httpx.HTTPStatusError as exc:
-            log.error("reset failed: %s — %s", exc.response.status_code, exc.response.text)
+            log.error(
+                "reset failed: %s - %s", exc.response.status_code, exc.response.text
+            )
             raise HTTPException(status_code=502, detail=exc.response.text) from exc
 
-    log.info("Organisation reset: %s", r.json())
+    log.info("Organization reset: %s", r.json())
     return ResetResponse(ok=True)
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Supermemory run notes

This PR updates the Supermemory results using the local/self-hosted Supermemory server release `server-v0.0.3`.

For reproducibility, the wrapper runs the official Linux x64 server binary inside a pinned Docker image. The Dockerfile downloads the versioned release artifact and verifies its SHA256 before packaging it.

- Binary URL: `https://github.com/supermemoryai/supermemory/releases/download/server-v0.0.3/supermemory-server-linux-x64`
- Binary SHA256: `4036486514bd3511099e8f8642e1c56ecc58550c5e194442e88a5438992c0957`
- Docker image: `tenurehq/precisionmembench-supermemory@sha256:b4ef936e7b03bea8882d590bd2ab91097c74e155695675a48a1b1baab33e17e5`
- Wrapper source: committed under `wrappers/supermemory/`